### PR TITLE
Disable default sshd and require keys

### DIFF
--- a/archiso-ff1/airootfs/etc/ssh/sshd_config.d/ff1.conf
+++ b/archiso-ff1/airootfs/etc/ssh/sshd_config.d/ff1.conf
@@ -1,0 +1,5 @@
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+ChallengeResponseAuthentication no
+PubkeyAuthentication yes
+PermitRootLogin prohibit-password

--- a/archiso-ff1/airootfs/etc/systemd/system-preset/90-default.preset
+++ b/archiso-ff1/airootfs/etc/systemd/system-preset/90-default.preset
@@ -1,4 +1,3 @@
-enable sshd.service
 enable bluetooth.service
 enable NetworkManager.service
 enable btrfs-subvolume-manager.service

--- a/archiso-ff1/airootfs/root/scripts/dev-ssh.sh
+++ b/archiso-ff1/airootfs/root/scripts/dev-ssh.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+SSHD_CONF="/etc/ssh/sshd_config.d/ff1.conf"
+
+usage() {
+  echo "Usage: $0 [on|off]"
+  echo "  on   - Disable ff1 config and use default SSH settings (password auth allowed)"
+  echo "  off  - Restore ff1 config (key-only authentication)"
+  exit 1
+}
+
+[[ $# -ne 1 ]] && usage
+
+case "$1" in
+  on)
+    if [[ ! -f "$SSHD_CONF" ]]; then
+      echo "SSH is already using default settings."
+      exit 0
+    fi
+    echo "Stopping sshd..."
+    systemctl stop sshd
+    echo "Disabling ff1 SSH config..."
+    mv "$SSHD_CONF" "${SSHD_CONF}.disabled"
+    echo "Enabling and starting sshd with default settings..."
+    systemctl enable --now sshd
+    echo "Done. SSH is now running with default settings (password authentication allowed)."
+    ;;
+  off)
+    if [[ ! -f "${SSHD_CONF}.disabled" ]]; then
+      echo "Error: ${SSHD_CONF}.disabled not found. Has 'on' been run first?"
+      exit 1
+    fi
+    if [[ -f "$SSHD_CONF" ]]; then
+      echo "ff1 SSH config is already active."
+      exit 0
+    fi
+    echo "Stopping sshd..."
+    systemctl stop sshd
+    echo "Restoring ff1 SSH config..."
+    mv "${SSHD_CONF}.disabled" "$SSHD_CONF"
+    echo "Done. SSH is restored to ff1 hardened settings (key-only authentication)."
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/archiso-ff1/profiledef.sh
+++ b/archiso-ff1/profiledef.sh
@@ -31,4 +31,5 @@ file_permissions=(
   ["/root/scripts/feral-update.sh"]="0:0:755"
   ["/root/scripts/factory_reset.sh"]="0:0:755"
   ["/root/scripts/btrfs-subvolume-manager.sh"]="0:0:755"
+  ["/root/scripts/dev-ssh.sh"]="0:0:700"
 )


### PR DESCRIPTION
## Summary
- Disable sshd from the default systemd preset
- Add sshd drop-in to require key-only auth and block password auth

## Testing
- Not run (image build only)