### PR TITLE
fix(ffos): use Crockford-style FF1 device IDs

### DIFF
--- a/archiso-ff1/airootfs/root/scripts/auto-install.sh
+++ b/archiso-ff1/airootfs/root/scripts/auto-install.sh
@@ -222,6 +222,7 @@ pacman-key --lsign-key AA6B250F2938F3CB
 echo "Setting up hostname..."
 DEVICE_ID_PREFIX="FF1-"
 MD5_LENGTH=8
+HOSTNAME_CHARSET="0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 
 # Get permanent MAC address with priority: ethernet > wifi > mobile
 get_permanent_mac() {
@@ -258,13 +259,13 @@ else
   MAC_HEX=$(echo "$MAC_ADDRESS" | tr -d ':')
   MD5_DIGEST=$(echo -n "$MAC_HEX" | xxd -r -p | md5sum | awk '{print $1}')
 
-  # Encode first 8 bytes of hash into base36
-  ALPHABET="0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  # Encode first 8 bytes of hash into a human-friendly charset
   RESULT_STRING=""
+  CHARSET_LENGTH=${#HOSTNAME_CHARSET}
   for (( i=0; i<MD5_LENGTH*2; i+=2 )); do
       BYTE_HEX="${MD5_DIGEST:i:2}"
       DEC=$((0x$BYTE_HEX))
-      CHAR=${ALPHABET:$((DEC % 36)):1}
+      CHAR=${HOSTNAME_CHARSET:$((DEC % CHARSET_LENGTH)):1}
       RESULT_STRING+=$CHAR
   done
 

--- a/archiso-ff1/airootfs/root/scripts/install-to-disk.sh
+++ b/archiso-ff1/airootfs/root/scripts/install-to-disk.sh
@@ -241,6 +241,7 @@ pacman-key --lsign-key AA6B250F2938F3CB
 echo "Setting up hostname..."
 DEVICE_ID_PREFIX="FF1-"
 MD5_LENGTH=8
+HOSTNAME_CHARSET="0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 
 # Get MAC address or fallback
 MAC_ADDRESS=$(ip link | grep -o -E 'link/ether ([0-9a-fA-F:]{17})' | awk '{print $2}' | sort | head -n1)
@@ -251,13 +252,13 @@ else
   MAC_HEX=$(echo "$MAC_ADDRESS" | tr -d ':')
   MD5_DIGEST=$(echo -n "$MAC_HEX" | xxd -r -p | md5sum | awk '{print $1}')
 
-  # Encode first 8 bytes of hash into base36
-  ALPHABET="0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  # Encode first 8 bytes of hash into a human-friendly charset
   RESULT_STRING=""
+  CHARSET_LENGTH=${#HOSTNAME_CHARSET}
   for (( i=0; i<MD5_LENGTH*2; i+=2 )); do
       BYTE_HEX="${MD5_DIGEST:i:2}"
       DEC=$((0x$BYTE_HEX))
-      CHAR=${ALPHABET:$((DEC % 36)):1}
+      CHAR=${HOSTNAME_CHARSET:$((DEC % CHARSET_LENGTH)):1}
       RESULT_STRING+=$CHAR
   done
 


### PR DESCRIPTION
## Summary
- replace FF1 hostname character set in installer ID generation with a Crockford-style base32 alphabet
- keep output length and format (`FF1-XXXXXXXX`) while removing visually ambiguous characters from suffix generation

## Changes
- `archiso-ff1/airootfs/root/scripts/auto-install.sh`
  - add `HOSTNAME_CHARSET` using `0123456789ABCDEFGHJKMNPQRSTVWXYZ`
  - replace fixed modulo-36 alphabet indexing with charset-length based lookup
- `archiso-ff1/airootfs/root/scripts/install-to-disk.sh`
  - add same charset change and modulo logic for the same deterministic hash-to-id mapping

## Why
FF1 IDs are easier to transcribe under stress and in mono fonts by removing ambiguous glyphs like I/L/O/U, reducing support and QA errors.

## Related
- https://github.com/feral-file/feral-file/issues/3286

## Validation
- `bash -n archiso-ff1/airootfs/root/scripts/auto-install.sh`
- `bash -n archiso-ff1/airootfs/root/scripts/install-to-disk.sh`
