### PR TITLE
ci: add agent guardrails and lint guardrails for ffos

### DIFF
--- a/.codex/agents/planner-researcher.toml
+++ b/.codex/agents/planner-researcher.toml
@@ -1,0 +1,11 @@
+name = "planner-researcher"
+description = "Read-only planning subagent for large FFOS architecture, workflow, and release questions. Use only when the request is both large and ambiguous."
+
+developer_instructions = """
+Read AGENTS.md, README.md, docs/DEVICE_LIFECYCLE.md, docs/SNAPSHOT_SYSTEM_V2_FLOW.md, and the relevant .cursor rules before advising.
+
+Summarize current ownership boundaries and safety invariants first. Prefer deletion or simplification before additive design. If the request depends on architectural direction or API contract direction, call out the TBD files owned by @lpopo0856 instead of inventing strategy. Return design branches, trade-offs, validation expectations, and a recommended smallest safe path.
+"""
+
+sandbox_mode = "read-only"
+

--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -1,0 +1,11 @@
+name = "reviewer"
+description = "Read-only FFOS reviewer. Use after implementation for a fresh-context review of safety risks, regressions, lint gaps, and missing documentation."
+
+developer_instructions = """
+Read and follow prompts/code-review.md and AGENTS.md.
+
+Review the current diff, touched files, and relevant lint/test output. Prioritize safety-critical update, rollback, recovery, packaging, and workflow risks. Also flag weak guardrails, missing comments that future agent sessions would need, and documentation drift. End with exactly one of: Verdict: accept or Verdict: revise.
+"""
+
+sandbox_mode = "read-only"
+

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,6 @@
+# Repo-local Codex config. Project-scoped agents live in .codex/agents/.
+
+[agents]
+max_threads = 6
+max_depth = 1
+

--- a/.cursor/agents/planner-researcher.md
+++ b/.cursor/agents/planner-researcher.md
@@ -1,0 +1,42 @@
+---
+name: planner-researcher
+model: premium
+description: Read-only planning sub-agent for large FFOS architecture, workflow, and release questions. Use only when the request is both large and ambiguous.
+readonly: true
+---
+
+You are the planning and research sub-agent for FFOS.
+
+Use this role only when the task is large enough and vague enough that multiple materially different designs are possible.
+
+Do not activate yourself for:
+
+- small direct edits;
+- straightforward lint or documentation work;
+- bounded workflow fixes with obvious scope;
+- requests where the user already gave a concrete implementation path.
+
+## Required repository context
+
+Before returning guidance, read:
+
+1. `AGENTS.md`
+2. `README.md`
+3. `docs/DEVICE_LIFECYCLE.md`
+4. `docs/SNAPSHOT_SYSTEM_V2_FLOW.md`
+5. `.cursor/rules/01-master-design.mdc`
+6. `.cursor/rules/10-architecture-direction-tbd.mdc`
+7. `.cursor/rules/15-api-design-tbd.mdc`
+8. `.cursor/rules/35-testing-and-guardrails.mdc`
+
+## Required behavior
+
+- Summarize the current relevant flow, repository ownership boundary, and invariants first.
+- Surface ambiguity instead of guessing.
+- When the missing architecture or API direction matters, call out the owner-owned TBD explicitly.
+- Prefer deletion, simplification, or boundary cleanup before additive designs.
+- Give design branches with trade-offs, risks, and rollback implications.
+- Define validation and guardrails for each viable branch.
+- Recommend a staged path with the smallest safe first change.
+
+Do not edit files unless the user explicitly asks.

--- a/.cursor/agents/reviewer.md
+++ b/.cursor/agents/reviewer.md
@@ -1,0 +1,24 @@
+---
+name: reviewer
+model: premium
+description: Read-only FFOS reviewer. Use after implementation for a fresh-context review of safety risks, regressions, lint gaps, and missing documentation.
+readonly: true
+---
+
+You are the FFOS reviewer.
+
+Read and follow `prompts/code-review.md` and `AGENTS.md`.
+
+Focus on:
+
+- safety-critical update, rollback, recovery, and packaging risks;
+- workflow regressions and maintainability problems;
+- missing or weak guardrail coverage;
+- missing comments or documentation where future amendment context would matter.
+
+You are read-only and must end with exactly one of:
+
+- `Verdict: accept`
+- `Verdict: revise`
+
+Do not edit files unless the user explicitly asks.

--- a/.cursor/rules/01-master-design.mdc
+++ b/.cursor/rules/01-master-design.mdc
@@ -1,0 +1,53 @@
+---
+description: Core FFOS repository boundaries and non-negotiable safety constraints.
+globs:
+  - ".github/**"
+  - "archiso-ff1/**"
+  - "docs/**"
+  - "AGENTS.md"
+alwaysApply: true
+---
+
+# Core FFOS Design Rule
+
+Use this rule for structural decisions, release automation changes, and runtime-image changes.
+
+## 1) Non-negotiable constraints
+
+- FFOS is the image assembly and release orchestration repository, not the home for arbitrary component logic that belongs in `ffos-user`.
+- Prefer replacing or deleting flawed workflow paths over adding more branching, flags, or compatibility logic.
+- Do not preserve legacy behavior unless the user explicitly asks for compatibility.
+- OTA, recovery, rollback, package signing, package publication, and boot entry management are safety-critical. Preserve their invariants when editing related code.
+- Keep build logic deterministic, explicit, and auditable.
+- Prefer scripts and workflows that make failure states visible instead of hiding them behind silent fallbacks.
+- When touching non-obvious logic, add comments that preserve context for future agent sessions:
+  - why this branch or block exists;
+  - what invariant it protects;
+  - what trade-off was accepted;
+  - what would break if it were removed or changed casually.
+
+## 2) Repository boundary
+
+- This repo owns:
+  - ArchISO profile configuration;
+  - root filesystem overlay and runtime scripts already stored here;
+  - packaging/release orchestration;
+  - GitHub Actions workflows and shared CI actions;
+  - FFOS documentation for device/update/build behavior.
+- `ffos-user` owns:
+  - component implementation source;
+  - user payloads and user-specific filesystem content;
+  - component-level business logic unless explicitly mirrored here as runtime integration.
+
+## 3) Safety model to preserve
+
+- Candidate boots must remain recoverable.
+- Known-good default boot behavior must remain intact unless the change explicitly redesigns it.
+- Recovery and rollback paths must remain understandable from code and docs.
+- Package publication and signing steps must remain traceable and hard to misuse.
+
+## 4) Planning activation
+
+- Use deeper planning when the request changes runtime architecture, update/recovery semantics, image assembly strategy, or cross-repo ownership.
+- Do not invoke planning for narrow documentation, lint, or workflow readability fixes.
+

--- a/.cursor/rules/10-architecture-direction-tbd.mdc
+++ b/.cursor/rules/10-architecture-direction-tbd.mdc
@@ -1,0 +1,38 @@
+---
+description: Repository-owner architectural direction placeholder. Agents must not invent this.
+globs:
+  - ".github/**"
+  - "archiso-ff1/**"
+  - "docs/**"
+  - "AGENTS.md"
+alwaysApply: true
+---
+
+# Architecture Direction Rule — TBD By Repository Owner
+
+Status: `TBD`
+
+Owner: `@lpopo0856`
+
+This file is intentionally a placeholder. It should capture the architectural direction that future agent sessions must optimize for.
+
+## Owner-owned TBDs
+
+- Which responsibilities must remain in `ffos` versus move to `ffos-user`.
+- Desired long-term split between reusable workflow primitives, shell scripts, and image-time configuration.
+- Preferred direction for update/recovery orchestration complexity:
+  - keep current script-centric model;
+  - move toward more structured orchestration;
+  - other explicit target chosen by the repo owner.
+- How strongly the repo should bias toward:
+  - fewer larger workflows versus smaller composable workflows;
+  - fewer long scripts versus more narrowly scoped scripts;
+  - generated config versus committed config.
+- The architectural north star agents should aim for when simplifying or extending the repository.
+
+## Temporary agent behavior until filled
+
+- Do not invent strategic architecture direction.
+- Keep changes tactical, reversible, and local.
+- If a requested change depends on architectural direction, call out this TBD and ask for owner guidance.
+

--- a/.cursor/rules/15-api-design-tbd.mdc
+++ b/.cursor/rules/15-api-design-tbd.mdc
@@ -1,0 +1,32 @@
+---
+description: Repository-owner API and contract direction placeholder. Agents must not invent this.
+globs:
+  - ".github/**"
+  - "archiso-ff1/**"
+  - "docs/**"
+  - "AGENTS.md"
+alwaysApply: true
+---
+
+# API And Contract Design Rule — TBD By Repository Owner
+
+Status: `TBD`
+
+Owner: `@lpopo0856`
+
+This file is intentionally incomplete. It should define how agents should reason about external contracts touched by FFOS.
+
+## Owner-owned TBDs
+
+- Contract posture for version metadata APIs consumed by update and recovery flows.
+- Expected stability guarantees for config payloads embedded into the image.
+- Rules for introducing, renaming, or deprecating runtime configuration keys.
+- Rules for cross-repo interfaces with `ffos-user`.
+- Documentation expectations when a workflow or runtime script changes an external contract.
+
+## Temporary agent behavior until filled
+
+- Do not invent or silently normalize new contract rules.
+- Prefer documenting the current observed contract rather than redefining it.
+- If a task requires contract design decisions, surface this gap and ask for owner direction.
+

--- a/.cursor/rules/20-build-release-constraints.mdc
+++ b/.cursor/rules/20-build-release-constraints.mdc
@@ -1,0 +1,32 @@
+---
+description: Build, release, and script readability constraints for FFOS.
+globs:
+  - ".github/**"
+  - "archiso-ff1/**"
+alwaysApply: true
+---
+
+# Build And Release Constraints
+
+## 1) Workflow design
+
+- Prefer small, named steps over dense monolithic shell blocks.
+- Keep step names descriptive enough that failed CI runs tell a readable story.
+- Reuse composite actions or workflow calls when it reduces duplication without hiding safety-critical behavior.
+- Set shell scripts to fail fast with `set -euo pipefail` when practical.
+- Keep environment-sensitive logic explicit and easy to audit.
+
+## 2) Script design
+
+- Prefer repository-owned scripts for complex shell logic rather than oversized inline workflow blocks.
+- Keep shell functions narrow and name them by intent.
+- Quote variables by default.
+- Use comments to preserve design constraints, recovery assumptions, and cross-repo expectations when the logic is not obvious.
+- When editing a dangerous path such as OTA, factory reset, rollback, or publishing, explain the preserved invariant in a nearby comment if the code does not already make it obvious.
+
+## 3) Readability over cleverness
+
+- Prefer explicit loops and conditionals over terser but less readable shell patterns.
+- Avoid hidden fallthrough behavior, silent retries, and ambiguous defaults in safety-critical paths.
+- Keep version/source selection logic easy to trace from docs to code.
+

--- a/.cursor/rules/35-testing-and-guardrails.mdc
+++ b/.cursor/rules/35-testing-and-guardrails.mdc
@@ -1,0 +1,34 @@
+---
+description: Required verification and lint guardrails for FFOS repository changes.
+globs:
+  - ".github/**"
+  - "archiso-ff1/**"
+  - "docs/**"
+  - "*.md"
+alwaysApply: true
+---
+
+# Testing And Guardrails Rule
+
+## 1) Required checks
+
+Run the relevant repository guardrails after changes:
+
+- `actionlint` for GitHub Actions workflow correctness.
+- `yamllint` for workflow and config readability.
+- `markdownlint-cli2` for documentation and agent-instruction quality.
+- `shellcheck` for repository-owned shell scripts.
+
+## 2) Scope expectations
+
+- If you change workflows, run workflow and YAML checks.
+- If you change shell scripts or ArchISO runtime logic, run shell linting.
+- If you change docs, rules, prompts, or agent files, run markdown linting.
+- If you cannot run a tool locally, say so clearly and rely on CI as the follow-up gate.
+
+## 3) Documentation as enforcement
+
+- Keep docs aligned with runtime behavior when they describe boot, update, recovery, packaging, or release flows.
+- Prefer documenting constraints and trade-offs near the changed code and in docs when both are needed.
+- Documentation lint failures are real failures in this repo; do not treat them as optional polish.
+

--- a/.cursor/rules/archiso-development.mdc
+++ b/.cursor/rules/archiso-development.mdc
@@ -1,54 +1,51 @@
 ---
-description: 
-globs: 
+description: FFOS ArchISO profile, runtime script, and rootfs overlay guidance.
+globs:
+  - "archiso-ff1/**"
 alwaysApply: false
 ---
+
 # ArchISO Development Guidelines
 
-## Image Configuration
-Working with the ArchISO profile in `archiso-ff1/` to build the FFOS image.
+Use this rule when editing the FFOS image profile or runtime scripts in `archiso-ff1/`.
 
-## Key Configuration Files
-- `profiledef.sh` - Main profile definition with build settings
-- `packages.x86_64` - List of packages to include in the ISO
-- `pacman.conf` - Package manager configuration
-- `airootfs/` - Filesystem overlay that becomes the live system
+## Core expectation
 
-## File Permissions & Ownership
-ALL files in the final system should be owned by `feralfile` (1000:1000) unless they are system files.
+Every change should preserve a coherent bootable image and a debuggable runtime. Prefer explicit, well-commented changes over clever compact edits.
 
-Key permission patterns in `profiledef.sh`:
-- `/home/feralfile/` and subdirectories: `1000:1000:755`
-- Scripts in `/home/feralfile/scripts/`: `1000:1000:755`
-- System config files: `0:0:644` or appropriate system permissions
+## Key configuration files
 
-## Filesystem Overlay Structure (`airootfs/`)
-- `etc/` - System configuration (polkit rules, systemd services)
-- `home/feralfile/` - User space with `.config/`, `.logs/`, `.state/`, `scripts/`
-- `usr/local/bin/` - Custom binaries and services
-- `opt/` - Application data (UI bundles, etc.)
+- `profiledef.sh`: top-level image profile, permissions, and build-time behavior.
+- `packages.x86_64`: package set for the image.
+- `pacman.conf`: repository configuration for the image build.
+- `airootfs/`: filesystem overlay copied into the final image.
 
-## Polkit Rules (NOT sudo)
-Create rules in `airootfs/etc/polkit-1/rules.d/` for privilege escalation:
-- Network management (nmcli)
-- Time synchronization
-- System service control
-- Hardware access
+## Runtime structure
 
-## Package Management
-- Keep the ISO minimal - only include necessary packages
-- Group related packages logically in `packages.x86_64`
-- Consider package dependencies and conflicts
-- Use official Arch packages when possible
+- `airootfs/etc/`: system configuration, systemd units, initcpio hooks, polkit rules.
+- `airootfs/root/scripts/`: image-owned operational scripts. These are safety-relevant and should be easy to audit.
+- `airootfs/usr/local/bin/`: helper binaries and runtime utilities already committed into the image.
 
-## Systemd Integration
-- Service files go in `airootfs/etc/systemd/system/`
-- Use proper service dependencies and ordering
-- Implement `setup.target` vs `kiosk.target` isolation
-- Enable services in the appropriate target
+## Commenting standard for shell and boot logic
 
-## Build & Testing
-- Test the ISO in a VM before deploying to hardware
-- Verify all services start correctly
-- Check file permissions after build
-- Validate network connectivity and BLE functionality
+- Prefer higher-than-normal comment density around non-obvious logic.
+- Capture the design intent, invariant, rollback assumption, and trade-off when a future maintainer could otherwise misread the code.
+- Add comments before risky blocks such as:
+  - subvolume promotion or cleanup;
+  - boot-entry generation;
+  - package key handling;
+  - recovery selection;
+  - update and rollback branching.
+
+## Permissions and ownership
+
+- Final-system ownership and mode choices must remain intentional and reviewable.
+- When changing ownership or mode rules, explain why the change is safe.
+- Avoid broad permission expansion as a convenience shortcut.
+
+## Package and service posture
+
+- Keep the ISO minimal and purpose-driven.
+- Prefer official packages when possible.
+- Keep systemd service dependencies explicit and readable.
+- Avoid adding services or packages without documenting the operational reason.

--- a/.cursor/rules/project-overview.mdc
+++ b/.cursor/rules/project-overview.mdc
@@ -1,5 +1,28 @@
 ---
-description:
+description: Quick FFOS repository map and domain vocabulary.
 globs:
 alwaysApply: false
 ---
+
+# FFOS Project Overview
+
+## Repository map
+
+- `.github/workflows/`: build, package, publish, and image-generation automation.
+- `.github/actions/setup-pacman/`: shared package-manager setup primitive.
+- `archiso-ff1/`: ArchISO profile, rootfs overlay, runtime scripts, and boot files.
+- `docs/`: current device lifecycle and snapshot/update behavior references.
+
+## Primary flows
+
+- Build components from `ffos-user`.
+- Publish packages and repository metadata to R2.
+- Build FFOS images from the profile plus user payloads.
+- Preserve OTA, factory reset, recovery update, and rollback behavior described in `docs/SNAPSHOT_SYSTEM_V2_FLOW.md`.
+
+## Vocabulary
+
+- `FFOS`: the image and release system in this repository.
+- `ffos-user`: the separate repository containing components and user payloads.
+- `candidate boot`: a one-shot boot into a staged update or recovery snapshot.
+- `known-good boot`: the default boot path that must remain recoverable.

--- a/.cursor/rules/review-workflow.mdc
+++ b/.cursor/rules/review-workflow.mdc
@@ -1,0 +1,13 @@
+---
+alwaysApply: true
+---
+
+# Review Workflow Rule
+
+When implementation is complete, run a review loop until the reviewer qualifies the change. Do not commit, push, or create a PR before `Verdict: accept`.
+
+1. Handoff: produce a compact handoff with goal, files changed, key decisions, checks run, and unresolved risks or TBDs.
+2. Review: invoke the reviewer sub-agent with the handoff, `git diff --stat`, `git diff`, and any lint/test output.
+3. Revise when needed: if the reviewer returns `Verdict: revise`, fix the findings, rerun the checks, and review again.
+4. Ship only after acceptance: once the reviewer returns `Verdict: accept`, commit, push, and create the PR if requested.
+

--- a/.github/workflows/build-components.yaml
+++ b/.github/workflows/build-components.yaml
@@ -23,14 +23,19 @@ on:
         default: 'GitHub Actions'
       environment:
         description: 'Environment for Sentry release'
-        required: true
+        required: false
         type: string
         default: 'Development'
       ffos_user_ref:
         description: 'ffos-user repository reference'
-        required: true
+        required: false
         type: string
         default: 'develop'
+      pacman_snapshot:
+        description: 'Pacman repository snapshot to use'
+        required: false
+        type: string
+        default: 'latest'
       container_image:
         description: 'Container image to use for the build'
         required: true
@@ -59,7 +64,7 @@ permissions:
 
 jobs:
   build-component:
-    environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
+    environment: ${{ inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
     runs-on: ubuntu-latest
     container:
       image: ${{ inputs.container_image }}
@@ -72,7 +77,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: feral-file/ffos-user
-          ref: ${{ inputs.ffos_user_ref || github.event.inputs.ffos_user_ref }}
+          ref: ${{ inputs.ffos_user_ref }}
           path: ffos-user
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
 
@@ -86,17 +91,17 @@ jobs:
         working-directory: ffos-user/components/${{ inputs.component }}
         run: |
           if [ -f "Cargo.toml" ]; then
-            echo "type=rust" >> $GITHUB_OUTPUT
+            echo "type=rust" >> "$GITHUB_OUTPUT"
             # Get the binary name from Cargo.toml if possible
             if [ -f "Cargo.toml" ]; then
               BINARY_NAME=$(grep -m 1 'name\s*=' Cargo.toml | cut -d '"' -f 2 || echo "${{ inputs.component }}")
-              echo "binary_name=${BINARY_NAME}" >> $GITHUB_OUTPUT
+              echo "binary_name=${BINARY_NAME}" >> "$GITHUB_OUTPUT"
             else
-              echo "binary_name=${{ inputs.component }}" >> $GITHUB_OUTPUT
+              echo "binary_name=${{ inputs.component }}" >> "$GITHUB_OUTPUT"
             fi
           else
-            echo "type=go" >> $GITHUB_OUTPUT
-            echo "binary_name=${{ inputs.component }}" >> $GITHUB_OUTPUT
+            echo "type=go" >> "$GITHUB_OUTPUT"
+            echo "binary_name=${{ inputs.component }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install Go Dependencies
@@ -113,15 +118,15 @@ jobs:
         id: set-version
         run: |
           VERSION="${{ inputs.version }}"
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build Pacman Package
         working-directory: ffos-user/components/${{ inputs.component }}
         run: |
           set -euo pipefail
-          COMP=${{ inputs.component }}
-          VER=${VERSION}
+          COMP="${{ inputs.component }}"
+          VER="${VERSION}"
           TARBALL="${COMP}_${VER}.tar.gz"
 
           PROFILE=release
@@ -139,8 +144,8 @@ jobs:
             # PKGBUILD for Rust component
             cat <<EOF > PKGBUILD
           # Maintainer: ${{ inputs.maintainer }}
-          pkgname=${COMP}
-          pkgver=${VER}
+          pkgname="${COMP}"
+          pkgver="${VER}"
           pkgrel=1
           pkgdesc="${{ inputs.description }}"
           arch=('x86_64' 'aarch64')
@@ -155,7 +160,7 @@ jobs:
 
           build() {
             cd "\$srcdir"
-            cargo build --profile=${PROFILE}
+            cargo build --profile="${PROFILE}"
           }
 
           package() {
@@ -166,8 +171,8 @@ jobs:
             # PKGBUILD for Go component
             cat <<EOF > PKGBUILD
           # Maintainer: ${{ inputs.maintainer }}
-          pkgname=${COMP}
-          pkgver=${VER}
+          pkgname="${COMP}"
+          pkgver="${VER}"
           pkgrel=1
           pkgdesc="${{ inputs.description }}"
           arch=('x86_64' 'aarch64')

--- a/.github/workflows/build-image-from-tags.yml
+++ b/.github/workflows/build-image-from-tags.yml
@@ -428,7 +428,7 @@ jobs:
         run: |
           cd /build
           mkarchiso -v -w /build/work -o /build/out /build/archiso-ff1
-          ISO_FILE=$(ls /build/out/*.iso | head -n 1)
+          ISO_FILE=$(find /build/out -maxdepth 1 -type f -name '*.iso' | head -n 1)
           if [ -f "$ISO_FILE" ]; then
             IMAGE_TYPE="${{ inputs.dev_iso && 'dev-' || '' }}"
             if [ "${{ github.ref_name }}" = "release" ]; then

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,95 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - main
+    paths:
+      - ".github/**"
+      - ".cursor/**"
+      - ".codex/**"
+      - "archiso-ff1/**"
+      - "docs/**"
+      - "*.md"
+      - "AGENTS.md"
+      - "opencode.json"
+
+permissions:
+  contents: read
+
+jobs:
+  workflow-lint:
+    name: Workflow lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1
+        with:
+          args: -color
+
+  yaml-and-docs:
+    name: YAML and docs lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install yamllint
+        run: python -m pip install --upgrade pip yamllint
+
+      - name: Install markdownlint-cli2
+        run: npm install --global markdownlint-cli2
+
+      - name: Run yamllint
+        run: yamllint .yamllint.yaml .github/workflows/lint.yaml .github/actions/setup-pacman/action.yml
+
+      - name: Run markdownlint-cli2
+        run: markdownlint-cli2 "AGENTS.md" "PLANS.md" ".cursor/**/*.md" "prompts/**/*.md"
+
+  shell-lint:
+    name: Shell lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install ShellCheck
+        run: sudo apt-get update && sudo apt-get install --yes shellcheck
+
+      - name: Run ShellCheck on repository-owned scripts
+        run: |
+          set -euo pipefail
+          mapfile -t shell_files < <(
+            find archiso-ff1 -type f \
+              \( -name '*.sh' \
+              -o -name '.bash_profile' \
+              -o -name '.automated_script.sh' \
+              -o -path '*/dispatcher.d/*' \
+              -o -path '*/initcpio/hooks/*' \
+              -o -path '*/initcpio/install/*' \) \
+              ! -path '*/usr/local/bin/vmagent-prod' \
+              ! -path '*/usr/local/bin/websocat' \
+              | sort
+          )
+
+          if [ "${#shell_files[@]}" -eq 0 ]; then
+            echo "No shell files found."
+            exit 0
+          fi
+
+          printf '%s\0' "${shell_files[@]}" | xargs -0 shellcheck -x

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run actionlint
-        uses: rhysd/actionlint@v1
+        uses: rhysd/actionlint@v1.7.12
         with:
           args: -color
 

--- a/.github/workflows/manual-build-components.yaml
+++ b/.github/workflows/manual-build-components.yaml
@@ -94,17 +94,17 @@ jobs:
         working-directory: ffos-user/components/${{ inputs.component }}
         run: |
           if [ -f "Cargo.toml" ]; then
-            echo "type=rust" >> $GITHUB_OUTPUT
+            echo "type=rust" >> "$GITHUB_OUTPUT"
             # Get the binary name from Cargo.toml if possible
             if [ -f "Cargo.toml" ]; then
               BINARY_NAME=$(grep -m 1 'name\s*=' Cargo.toml | cut -d '"' -f 2 || echo "${{ inputs.component }}")
-              echo "binary_name=${BINARY_NAME}" >> $GITHUB_OUTPUT
+              echo "binary_name=${BINARY_NAME}" >> "$GITHUB_OUTPUT"
             else
-              echo "binary_name=${{ inputs.component }}" >> $GITHUB_OUTPUT
+              echo "binary_name=${{ inputs.component }}" >> "$GITHUB_OUTPUT"
             fi
           else
-            echo "type=go" >> $GITHUB_OUTPUT
-            echo "binary_name=${{ inputs.component }}" >> $GITHUB_OUTPUT
+            echo "type=go" >> "$GITHUB_OUTPUT"
+            echo "binary_name=${{ inputs.component }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install Go Dependencies
@@ -121,15 +121,15 @@ jobs:
         id: set-version
         run: |
           VERSION="${{ inputs.version }}"
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build Pacman Package
         working-directory: ffos-user/components/${{ inputs.component }}
         run: |
           set -euo pipefail
-          COMP=${{ inputs.component }}
-          VER=${VERSION}
+          COMP="${{ inputs.component }}"
+          VER="${VERSION}"
           TARBALL="${COMP}_${VER}.tar.gz"
 
           PROFILE=release
@@ -147,8 +147,8 @@ jobs:
             # PKGBUILD for Rust component
             cat <<EOF > PKGBUILD
           # Maintainer: ${{ inputs.maintainer }}
-          pkgname=${COMP}
-          pkgver=${VER}
+          pkgname="${COMP}"
+          pkgver="${VER}"
           pkgrel=1
           pkgdesc="${{ inputs.description }}"
           arch=('x86_64' 'aarch64')
@@ -163,7 +163,7 @@ jobs:
 
           build() {
             cd "\$srcdir"
-            cargo build --profile=${PROFILE}
+            cargo build --profile="${PROFILE}"
           }
 
           package() {
@@ -174,8 +174,8 @@ jobs:
             # PKGBUILD for Go component
             cat <<EOF > PKGBUILD
           # Maintainer: ${{ inputs.maintainer }}
-          pkgname=${COMP}
-          pkgver=${VER}
+          pkgname="${COMP}"
+          pkgver="${VER}"
           pkgrel=1
           pkgdesc="${{ inputs.description }}"
           arch=('x86_64' 'aarch64')

--- a/.github/workflows/manual-push-pacman-repo.yaml
+++ b/.github/workflows/manual-push-pacman-repo.yaml
@@ -79,10 +79,10 @@ jobs:
       - name: Generate Pacman Database - repo feralfile
         working-directory: repo/x86_64
         run: |
-          sorted_pkgs=$(printf '%s\n' *.pkg.tar.zst | sort -V)
+          mapfile -t sorted_pkgs < <(printf '%s\n' *.pkg.tar.zst | sort -V)
           echo "Adding packages in order:"
-          printf '  %s\n' $sorted_pkgs
-          repo-add feralfile.db.tar.gz $sorted_pkgs
+          printf '  %s\n' "${sorted_pkgs[@]}"
+          repo-add feralfile.db.tar.gz "${sorted_pkgs[@]}"
 
       - name: Configure AWS credentials (OIDC for KMS)
         uses: aws-actions/configure-aws-credentials@v4
@@ -129,7 +129,7 @@ jobs:
           rclone lsf "r2:${{ vars.CLOUDFLARE_R2_BUCKET_NAME }}/${{ github.ref_name }}/os/x86_64/" \
             --include "*.pkg.tar.zst" > all_packages.txt
 
-          while read pkgfile; do
+          while IFS= read -r pkgfile; do
             base=${pkgfile%.pkg.tar.zst}
             base=${base%-x86_64}
 

--- a/.github/workflows/pacman-repo.yaml
+++ b/.github/workflows/pacman-repo.yaml
@@ -5,24 +5,29 @@ on:
     inputs:
       environment:
         description: 'Environment for the build'
-        required: true
+        required: false
         type: string
         default: 'Development'
+      pacman_snapshot:
+        description: 'Pacman repository snapshot to use'
+        required: false
+        type: string
+        default: 'latest'
       container_image:
         description: 'Container image to use for the build'
         required: true
         type: string
     secrets:
-        CLOUDFLARE_ACCOUNT_ID:
-          required: true
-        CLOUDFLARE_ACCESS_KEY_ID:
-          required: true
-        CLOUDFLARE_SECRET_ACCESS_KEY:
-          required: true
-        AWS_KMS_FF1_RELEASE_SIGNER_ROLE_ARN:
-          required: true
-        AWS_KMS_FF1_RELEASE_SIGNING_KEY_ID:
-          required: true
+      CLOUDFLARE_ACCOUNT_ID:
+        required: true
+      CLOUDFLARE_ACCESS_KEY_ID:
+        required: true
+      CLOUDFLARE_SECRET_ACCESS_KEY:
+        required: true
+      AWS_KMS_FF1_RELEASE_SIGNER_ROLE_ARN:
+        required: true
+      AWS_KMS_FF1_RELEASE_SIGNING_KEY_ID:
+        required: true
 
 permissions:
   id-token: write
@@ -30,7 +35,7 @@ permissions:
 
 jobs:
   update-repo:
-    environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
+    environment: ${{ inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
     runs-on: ubuntu-latest
     container:
       image: ${{ inputs.container_image }}
@@ -71,10 +76,10 @@ jobs:
       - name: Generate Pacman Database - repo feralfile
         working-directory: repo/x86_64
         run: |
-          sorted_pkgs=$(printf '%s\n' *.pkg.tar.zst | sort -V)
+          mapfile -t sorted_pkgs < <(printf '%s\n' *.pkg.tar.zst | sort -V)
           echo "Adding packages in order:"
-          printf '  %s\n' $sorted_pkgs
-          repo-add feralfile.db.tar.gz $sorted_pkgs
+          printf '  %s\n' "${sorted_pkgs[@]}"
+          repo-add feralfile.db.tar.gz "${sorted_pkgs[@]}"
 
       - name: Configure AWS credentials (OIDC for KMS)
         uses: aws-actions/configure-aws-credentials@v4
@@ -121,7 +126,7 @@ jobs:
           rclone lsf "r2:${{ vars.CLOUDFLARE_R2_BUCKET_NAME }}/${{ github.ref_name }}/os/x86_64/" \
             --include "*.pkg.tar.zst" > all_packages.txt
 
-          while read pkgfile; do
+          while IFS= read -r pkgfile; do
             base=${pkgfile%.pkg.tar.zst}
             base=${base%-x86_64}
 

--- a/.github/workflows/resolve-container.yaml
+++ b/.github/workflows/resolve-container.yaml
@@ -25,12 +25,12 @@ jobs:
         run: |
           case "${{ inputs.pacman_snapshot }}" in
             "2025/11/25")
-              echo "image=archlinux:base-20251214.0.467559" >> $GITHUB_OUTPUT
+              echo "image=archlinux:base-20251214.0.467559" >> "$GITHUB_OUTPUT"
               ;;
             "2025/05/31")
-              echo "image=archlinux:base-20250525.0.354646" >> $GITHUB_OUTPUT
+              echo "image=archlinux:base-20250525.0.354646" >> "$GITHUB_OUTPUT"
               ;;
             *)
-              echo "image=archlinux:latest" >> $GITHUB_OUTPUT
+              echo "image=archlinux:latest" >> "$GITHUB_OUTPUT"
               ;;
           esac

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "default": true,
+    "MD013": {
+      "line_length": 120,
+      "code_blocks": false,
+      "tables": false
+    },
+    "MD024": {
+      "allow_different_nesting": true
+    },
+    "MD033": false,
+    "MD041": false
+  }
+}
+

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,3 @@
+severity=style
+external-sources=true
+

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,20 @@
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+  brackets:
+    max-spaces-inside: 1
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: enable
+  document-start: disable
+  line-length:
+    max: 120
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true
+  truthy:
+    allowed-values:
+      - "true"
+      - "false"
+    check-keys: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,121 @@
+# AGENTS.md — FFOS Repository Contract
+
+This file defines repository-level constraints for coding agents working in FFOS.
+Detailed implementation behavior lives in `.cursor/rules/`, while cross-tool
+sub-agent definitions live in `.cursor/agents/`, `.codex/agents/`, and
+`opencode.json`.
+
+## Repository overview
+
+- Project: FFOS build and release repository for FF1 devices.
+- Core responsibility: build Arch Linux-based FFOS images, stage packages from
+  `ffos-user`, publish artifacts, and preserve safe update and recovery flows.
+- Primary surfaces in this repo:
+  - `.github/workflows/` for build, packaging, and release automation.
+  - `.github/actions/` for shared CI primitives.
+  - `archiso-ff1/` for ISO profile, boot files, rootfs overlay, and runtime scripts.
+  - `docs/` for device lifecycle, snapshot/update flow, and repository context.
+- Cross-repo boundary: this repo owns FFOS image assembly and release
+  orchestration. `ffos-user` owns component code and user payloads unless a
+  workflow or documented integration explicitly says otherwise.
+
+## Non-negotiables
+
+- Prefer deleting or replacing confusing build/release paths over layering more conditional logic onto them.
+- Do not preserve legacy build behavior, fallback branches, or compatibility
+  shims unless the user explicitly asks for that behavior to remain.
+- Keep ownership boundaries explicit:
+  - image assembly, boot flow, package publication, and update orchestration belong here;
+  - component business logic belongs in `ffos-user` unless this repo already
+    owns the runtime script or image-level integration.
+- Treat OTA, recovery, rollback, boot entry generation, package signing, and
+  publication as safety-critical flows. Any change must preserve rollback and
+  known-good boot behavior.
+- Prefer deterministic, auditable shell and workflow logic over clever compact scripts.
+- For non-obvious logic, prefer more comments than usual. Leave durable context for later agent sessions:
+  - why the block exists;
+  - what invariants it must preserve;
+  - what failure mode or rollback risk it is protecting against;
+  - the chosen trade-off and the rejected alternative when that context will matter later.
+- Do not add decorative comments that restate syntax. Comments must earn their
+  keep as future amendment context.
+
+## Required context before structural changes
+
+Before changing architecture, workflow orchestration, boot/update behavior, or release/publishing behavior:
+
+1. Read `README.md`.
+2. Read `docs/DEVICE_LIFECYCLE.md`.
+3. Read `docs/SNAPSHOT_SYSTEM_V2_FLOW.md`.
+4. Read the relevant `.cursor/rules/*.mdc` files.
+5. Summarize the current flow, repository boundary, invariants, and rollback
+   expectations before implementing.
+
+Canonical sequence for structural work:
+`context -> design -> tasks -> implementation -> verification`
+
+If the work is large or ambiguous, use `PLANS.md` when it exists. If
+`PLANS.md` does not exist in this repo, create a short design note in the PR
+description or docs instead of silently improvising.
+
+## Architecture and API direction
+
+- `.cursor/rules/10-architecture-direction-tbd.mdc` is intentionally incomplete.
+- `.cursor/rules/15-api-design-tbd.mdc` is intentionally incomplete.
+- Repository owner action required: `@lpopo0856` should fill these with the
+  target architectural direction and API contract posture that future agent
+  sessions must aim toward.
+- Until those files are completed, agents must not invent new strategic
+  architecture or API conventions. If a task depends on that direction, call
+  out the gap and keep changes tactical and reversible.
+
+## Required development sequence
+
+1. Start with the smallest repository-owned change that solves the problem.
+2. Prefer workflow/script cleanup before additive branching or new flags.
+3. Add or expand comments around non-obvious shell/workflow logic when you
+   touch it.
+4. Run the strict repository guardrails that apply to the changed files.
+5. If you changed safety-critical update or boot logic, explain the preserved
+   invariants in the PR.
+
+## Guardrails and verification
+
+Run the relevant checks after changes:
+
+- GitHub Actions linting via `actionlint`.
+- YAML linting via `yamllint`.
+- Markdown/documentation linting via `markdownlint-cli2`.
+- Shell linting via `shellcheck` for repository-owned scripts.
+
+If a check cannot run locally, say so explicitly and rely on CI as the next gate.
+
+## Definition of done
+
+A task is complete only when:
+
+1. Repository instructions remain aligned across `AGENTS.md`, Cursor rules,
+   Codex/OpenCode config, and reviewer prompts.
+2. Changed workflows or scripts are readable, commented where needed, and
+   lint-clean or have documented follow-up.
+3. Safety-critical flows still preserve the current rollback/update model
+   unless the user explicitly requested a design change.
+4. Any unresolved architecture or API guidance gaps are called out as TBDs for `@lpopo0856`.
+
+## Review workflow
+
+After implementation, run a review loop before committing or opening a PR:
+
+1. Produce a compact handoff with goal, files changed, key decisions,
+   trade-offs, and checks run.
+2. Invoke the reviewer sub-agent with fresh context.
+3. If the reviewer returns `Verdict: revise`, address the findings and rerun
+   the review.
+4. Commit, push, and open a PR only after the reviewer returns `Verdict: accept`.
+
+## Commit format
+
+Use Conventional Commits:
+
+- `<type>(<optional-scope>): <description>`
+- Types: `feat`, `fix`, `refactor`, `test`, `docs`, `ci`, `build`, `chore`, `perf`, `style`

--- a/PLANS.md
+++ b/PLANS.md
@@ -1,0 +1,71 @@
+# Execution Plans For FFOS
+
+An execution plan in this repository is a living design-and-delivery document
+for large features, safety-critical behavior changes, workflow architecture
+changes, or vague requests that cannot be implemented safely without first
+turning them into a concrete plan.
+
+## When a plan is required
+
+Use a plan when at least one of these is true:
+
+- The request changes OTA, recovery, rollback, boot behavior, package publication, or release orchestration.
+- The request is large, vague, or could be satisfied by multiple materially different designs.
+- The work changes repo ownership boundaries between `ffos` and `ffos-user`.
+- The work touches multiple workflows or both CI and runtime-image behavior.
+
+Do not require a plan for small documentation edits, isolated lint fixes, or narrow readability changes with obvious scope.
+
+## Required planning inputs
+
+Before writing or updating a plan, read:
+
+1. `AGENTS.md`
+2. `README.md`
+3. `docs/DEVICE_LIFECYCLE.md`
+4. `docs/SNAPSHOT_SYSTEM_V2_FLOW.md`
+5. `.cursor/rules/01-master-design.mdc`
+6. `.cursor/rules/10-architecture-direction-tbd.mdc`
+7. `.cursor/rules/15-api-design-tbd.mdc`
+8. `.cursor/rules/35-testing-and-guardrails.mdc`
+
+## Planning rules
+
+- Summarize the current relevant flow and invariants first.
+- Prefer deletion, simplification, or boundary cleanup before additive designs.
+- Explicitly call out when architectural or API direction is blocked on the
+  owner-owned TBD files.
+- For each viable branch, list:
+  - the design goal;
+  - trade-offs;
+  - rollback or safety implications;
+  - required validation and guardrails.
+- Recommend the smallest safe first slice.
+
+## Plan template
+
+```md
+# <Short action-oriented title>
+
+## Purpose / Big Picture
+
+## Current Context
+
+## Constraints And Invariants
+
+## Open Questions
+
+## Design Branches
+
+## Chosen Direction
+
+## Validation Plan
+
+## Milestones
+
+## Progress
+
+## Decision Log
+
+## Risks And Recovery
+```

--- a/archiso-ff1/airootfs/etc/NetworkManager/dispatcher.d/09-timezone
+++ b/archiso-ff1/airootfs/etc/NetworkManager/dispatcher.d/09-timezone
@@ -39,8 +39,7 @@ query_service() {
     local response
     local tz
     
-    response=$(curl -sf --max-time "$TIMEOUT" "$url" 2>/dev/null)
-    if [ $? -eq 0 ] && [ -n "$response" ]; then
+    if response=$(curl -sf --max-time "$TIMEOUT" "$url" 2>/dev/null) && [ -n "$response" ]; then
         tz=$(extract_tz "$response" "$filter")
         if [ -n "$tz" ] && validate_timezone "$tz"; then
             echo "$tz"

--- a/archiso-ff1/airootfs/etc/initcpio/hooks/btrfs-rollback
+++ b/archiso-ff1/airootfs/etc/initcpio/hooks/btrfs-rollback
@@ -1,8 +1,11 @@
+#!/bin/bash
+
 run_hook() {
   mkdir -p /run
   LOG="/run/btrfs-rollback.log"
   local mode="" 
 
+  # shellcheck disable=SC2013
   for param in $(cat /proc/cmdline); do
     case "$param" in
       rollback=factory) mode="factory" ;;
@@ -17,6 +20,7 @@ run_hook() {
   mkdir -p /run/rollback
 
   local root_partuuid=""
+  # shellcheck disable=SC2013
   for param in $(cat /proc/cmdline); do
     case "$param" in
       root_partuuid=*) root_partuuid="${param#root_partuuid=}" ;;
@@ -114,12 +118,11 @@ run_hook() {
           if [[ -d "$backup_path" ]]; then
               echo "[btrfs-rollback] Restoring kernel files from $backup_path..." >> $LOG
               
-              rsync -a --delete --quiet "$backup_path/" "/run/rollback_boot/"
-                  
-              if [[ $? -eq 0 ]]; then
+              if rsync -a --delete --quiet "$backup_path/" "/run/rollback_boot/"; then
                   echo "[btrfs-rollback] Boot files synced successfully via rsync." >> $LOG
               else
-                  echo "[btrfs-rollback] ERROR: rsync failed with exit code $?" >> $LOG
+                  rsync_status=$?
+                  echo "[btrfs-rollback] ERROR: rsync failed with exit code $rsync_status" >> $LOG
                   umount /run/rollback_boot
                   umount /run/rollback
                   return 1

--- a/archiso-ff1/airootfs/root/.bash_profile
+++ b/archiso-ff1/airootfs/root/.bash_profile
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+
 # fix for screen readers
 if grep -Fqa 'accessibility=' /proc/cmdline &> /dev/null; then
     setopt SINGLE_LINE_ZLE

--- a/archiso-ff1/airootfs/root/scripts/auto-install.sh
+++ b/archiso-ff1/airootfs/root/scripts/auto-install.sh
@@ -146,7 +146,7 @@ EOF
 echo
 echo "Copying systemd-boot..."
 
-for i in {1..5}; do
+for _ in {1..5}; do
   if [ -e /dev/disk/by-label/ARCHISO_EFI ]; then
     break
   fi

--- a/archiso-ff1/airootfs/root/scripts/feral-recovery-update.sh
+++ b/archiso-ff1/airootfs/root/scripts/feral-recovery-update.sh
@@ -17,7 +17,13 @@ log_error() {
   echo "$(date '+%Y-%m-%dT%H:%M:%S%z') [ERROR] recovery_update message=\"$message\""
 }
 
-trap 'code=$?; log_error "EXCEPTION ERR: LINE=$LINENO CMD=\"$BASH_COMMAND\""; exit $code' ERR
+handle_err() {
+  local exit_code=$?
+  log_error "EXCEPTION ERR: LINE=$LINENO CMD=\"$BASH_COMMAND\""
+  exit "$exit_code"
+}
+
+trap handle_err ERR
 
 # Check if OTA updater is running - don't interfere with normal updates
 if /usr/bin/flock -n /run/feral-updater.lock -c "exit 0" 2>/dev/null; then

--- a/archiso-ff1/airootfs/root/scripts/feral-service-update.sh
+++ b/archiso-ff1/airootfs/root/scripts/feral-service-update.sh
@@ -17,7 +17,13 @@ log_error() {
   echo "$(date '+%Y-%m-%dT%H:%M:%S%z') [ERROR] id=$UNIQUE_ID message=\"$message\""
 }
 
-trap 'code=$?; log_error "EXCEPTION ERR: LINE=$LINENO CMD=\"$BASH_COMMAND\""; exit $code' ERR
+handle_err() {
+  local exit_code=$?
+  log_error "EXCEPTION ERR: LINE=$LINENO CMD=\"$BASH_COMMAND\""
+  exit "$exit_code"
+}
+
+trap handle_err ERR
 
 if [[ $# -lt 1 || -z "${1:-}" ]]; then
   echo "ERROR: Usage: $0 2025-06-19T16:00:00"

--- a/archiso-ff1/airootfs/root/scripts/feral-system-update.sh
+++ b/archiso-ff1/airootfs/root/scripts/feral-system-update.sh
@@ -17,7 +17,13 @@ log_error() {
   echo "$(date '+%Y-%m-%dT%H:%M:%S%z') [ERROR] id=$UNIQUE_ID message=\"$message\""
 }
 
-trap 'code=$?; log_error "EXCEPTION ERR: LINE=$LINENO CMD=\"$BASH_COMMAND\""; exit $code' ERR
+handle_err() {
+  local exit_code=$?
+  log_error "EXCEPTION ERR: LINE=$LINENO CMD=\"$BASH_COMMAND\""
+  exit "$exit_code"
+}
+
+trap handle_err ERR
 
 if [[ $# -lt 2 || -z "${1:-}" || -z "${2:-}" ]]; then
   echo "ERROR: Usage: $0 /path/to/image.zip 2025-06-19T16:00:00"

--- a/archiso-ff1/airootfs/root/scripts/feral-updater.sh
+++ b/archiso-ff1/airootfs/root/scripts/feral-updater.sh
@@ -32,7 +32,14 @@ cleanup() {
   flock -u 9 2>/dev/null || true
   rm -f "$LOCKFILE" 2>/dev/null || true
 }
-trap 'code=$?; log_error "EXCEPTION ERR: LINE=$LINENO CMD=\"$BASH_COMMAND\""; exit $code' ERR
+
+handle_err() {
+  local exit_code=$?
+  log_error "EXCEPTION ERR: LINE=$LINENO CMD=\"$BASH_COMMAND\""
+  exit "$exit_code"
+}
+
+trap handle_err ERR
 trap cleanup EXIT
 
 # Terminate recovery update if it's running to avoid conflicts

--- a/archiso-ff1/airootfs/root/scripts/feral-updater.sh
+++ b/archiso-ff1/airootfs/root/scripts/feral-updater.sh
@@ -57,7 +57,7 @@ fi
 
 ENV_MODE="test"
 if [[ -r /home/feralfile/.state/environment ]]; then
-  ENV_MODE="$(cat /home/feralfile/.state/environment 2>/dev/null | xargs)"
+  ENV_MODE="$(xargs < /home/feralfile/.state/environment 2>/dev/null)"
 fi
 
 if [[ "$ENV_MODE" == "live" ]]; then

--- a/archiso-ff1/airootfs/root/scripts/install-to-disk.sh
+++ b/archiso-ff1/airootfs/root/scripts/install-to-disk.sh
@@ -165,7 +165,7 @@ EOF
 echo
 echo "Copying systemd-boot..."
 
-for i in {1..5}; do
+for _ in {1..5}; do
   if [ -e /dev/disk/by-label/ARCHISO_EFI ]; then
     break
   fi

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": [
+    "AGENTS.md"
+  ],
+  "agent": {
+    "planner-researcher": {
+      "description": "Read-only planning sub-agent for large FFOS architecture, workflow, and release questions. Use only when the request is both large and ambiguous.",
+      "mode": "subagent",
+      "prompt": "Read AGENTS.md, README.md, docs/DEVICE_LIFECYCLE.md, docs/SNAPSHOT_SYSTEM_V2_FLOW.md, and the relevant .cursor rules before advising. Summarize current ownership boundaries and safety invariants first. Prefer deletion or simplification before additive design. If the request depends on architectural direction or API contract direction, call out the TBD files owned by @lpopo0856 instead of inventing strategy. Return design branches, trade-offs, validation expectations, and a recommended smallest safe path.",
+      "tools": {
+        "write": false,
+        "edit": false
+      }
+    },
+    "reviewer": {
+      "description": "Read-only FFOS reviewer. Use after implementation for a fresh-context review of safety risks, regressions, lint gaps, and missing documentation.",
+      "mode": "subagent",
+      "prompt": "{file:./prompts/code-review.md}",
+      "tools": {
+        "write": false,
+        "edit": false
+      }
+    }
+  },
+  "command": {
+    "review": {
+      "description": "Run a fresh-context FFOS code review using the shared repository review contract",
+      "template": "Review the current changes using prompts/code-review.md and AGENTS.md. Use this evidence:\\n- Diff: !`git diff --stat`\\n- Full diff: !`git diff`\\n- Relevant lint/test output if available\\n\\nReport findings in severity order, call out missing guardrails or documentation, and end with Verdict: accept or Verdict: revise.",
+      "agent": "reviewer",
+      "subtask": true
+    }
+  }
+}
+

--- a/prompts/code-review.md
+++ b/prompts/code-review.md
@@ -1,0 +1,45 @@
+# FFOS Review Contract
+
+Review for correctness first, then risk, then maintainability.
+
+## Primary focus
+
+Prioritize findings in this order:
+
+1. Safety-critical regressions in OTA, recovery, rollback, package publication, signing, or boot flow.
+2. Workflow and release automation bugs that could break CI/CD or artifact integrity.
+3. Missing or weak guardrails that allow risky changes to land without detection.
+4. Documentation or comment gaps that would make future amendment risky.
+
+## Reviewer posture
+
+- Be skeptical of hidden behavior changes.
+- Prefer concrete evidence from the diff, touched files, and checks.
+- Flag missing tests or lint coverage when the changed area needs them.
+- Call out owner-owned TBDs when a change starts setting architecture or API policy without approval.
+
+## Required output
+
+Use this structure:
+
+### Findings
+
+- List each issue in severity order.
+- Include file paths and a concise explanation of the risk.
+- If there are no findings, say `No blocking findings.`
+
+### Open questions
+
+- List any architecture/API direction gaps or assumptions that should be confirmed.
+- If none, say `None.`
+
+### Verification
+
+- Summarize what checks were provided or still missing.
+
+### Verdict
+
+End with exactly one of:
+
+- `Verdict: accept`
+- `Verdict: revise`


### PR DESCRIPTION
## Problem
FFOS had only minimal Cursor guidance and no shared agent contract across Cursor, Codex, and OpenCode. The repo also lacked a lightweight lint workflow for its highest-risk surfaces, so a few reusable workflow issues and shell pitfalls were able to sit unnoticed.

## Why it matters
This repo owns image assembly, release automation, and safety-critical update and recovery flows. Agent sessions need durable repository context, stronger commenting expectations, and explicit owner-owned TBDs so they do not invent architecture or API direction. CI also needs faster guardrails around workflow correctness, shell safety, and governance docs before expensive build jobs run.

## What changed
- Added repository-scoped agent guidance in `AGENTS.md` and `PLANS.md`.
- Added FFOS-specific Cursor rules, plus Cursor/Codex/OpenCode sub-agent config and a shared review prompt.
- Left architecture direction and API contract direction as explicit TBDs for the repo owner to fill in.
- Added a `Lint` workflow for `actionlint`, `yamllint`, `markdownlint-cli2`, and `shellcheck` on the new governance/config surface.
- Fixed real issues found while wiring the lint checks:
  - undefined reusable-workflow inputs for `pacman_snapshot`
  - contradictory `required + default` reusable-workflow inputs
  - shell safety/readability issues in workflow scripts and runtime shell scripts

## TBDs for @lpopo0856
Please fill these in so future agent sessions know the architectural direction to aim for:
- `.cursor/rules/10-architecture-direction-tbd.mdc`
- `.cursor/rules/15-api-design-tbd.mdc`

The key ask is to define the architectural north star you want agents to optimize for when they simplify or extend FFOS. In particular:
- what must stay in `ffos` vs move to `ffos-user`
- whether update/recovery orchestration should stay script-centric or move toward a more structured model
- how agents should treat external version/config contracts when they need to evolve them

## Acceptance checks
- `actionlint -color`
- `yamllint .yamllint.yaml .github/workflows/lint.yaml .github/actions/setup-pacman/action.yml`
- `markdownlint-cli2 "AGENTS.md" "PLANS.md" ".cursor/**/*.md" "prompts/**/*.md"`
- `find archiso-ff1 -type f \( -name '*.sh' -o -name '.bash_profile' -o -name '.automated_script.sh' -o -path '*/dispatcher.d/*' -o -path '*/initcpio/hooks/*' -o -path '*/initcpio/install/*' \) ! -path '*/usr/local/bin/vmagent-prod' ! -path '*/usr/local/bin/websocat' -print0 | xargs -0 shellcheck -x`
