### PR TITLE
ci: build ff-player static for FFOS image (feral-file#3397)

### DIFF
--- a/.github/workflows/build-image-from-tags.yml
+++ b/.github/workflows/build-image-from-tags.yml
@@ -54,6 +54,10 @@ on:
         required: false
         default: true
         type: boolean
+      ff_player_bundle_url:
+        description: "Optional: HTTPS URL to ff-player static .tar.gz (gzip). See workflow step for archive layout."
+        required: false
+        default: ""
 
 permissions:
   id-token: write
@@ -316,6 +320,22 @@ jobs:
           mkdir -p /build/archiso-ff1/airootfs/opt/feral/ui/player
           cp -r ffos-user/components/player-wrapper-ui/* /build/archiso-ff1/airootfs/opt/feral/ui/player/
           mkdir -p /build/archiso-ff1/airootfs/home/feralfile/.logs
+
+      - name: Install ff-player static bundle
+        if: ${{ inputs.ff_player_bundle_url != '' }}
+        run: |
+          set -euo pipefail
+          URL="${{ inputs.ff_player_bundle_url }}"
+          STAGE="$(mktemp -d)"
+          trap 'rm -rf "$STAGE"' EXIT
+          curl -fsSL "$URL" | tar -xzf - -C "$STAGE"
+          rm -rf /build/archiso-ff1/airootfs/opt/feral/ff-player
+          mkdir -p /build/archiso-ff1/airootfs/opt/feral/ff-player
+          if [[ -d "$STAGE/out" ]]; then
+            cp -a "$STAGE/out/." /build/archiso-ff1/airootfs/opt/feral/ff-player/
+          else
+            cp -a "$STAGE/." /build/archiso-ff1/airootfs/opt/feral/ff-player/
+          fi
 
       - name: Add Configs and Services
         run: |

--- a/.github/workflows/build-image-from-tags.yml
+++ b/.github/workflows/build-image-from-tags.yml
@@ -15,6 +15,11 @@ on:
         description: "ffos-user git tag/ref to checkout"
         required: true
         default: "v1.0.1"
+      ff_player_ref:
+        description: "ff-player repository reference to build static export"
+        required: true
+        default: "main"
+        type: string
       soak-test:
         description: "Include soak test"
         required: true
@@ -54,11 +59,6 @@ on:
         required: false
         default: true
         type: boolean
-      ff_player_bundle_url:
-        description: "Optional: HTTPS URL to ff-player static .tar.gz (gzip). See workflow step for archive layout."
-        required: false
-        default: ""
-
 permissions:
   id-token: write
   contents: read
@@ -74,9 +74,21 @@ jobs:
     with:
       pacman_snapshot: ${{ inputs.pacman_snapshot || github.event.inputs.pacman_snapshot }}
 
+  build-ff-player-static:
+    name: Build ff-player static
+    needs: permission-check
+    if: ${{ inputs.ff_player_ref != '' }}
+    uses: feral-file/ff-player/.github/workflows/build-ff-player-static.yaml@main
+    secrets:
+      REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+    with:
+      ff_player_ref: ${{ inputs.ff_player_ref || github.event.inputs.ff_player_ref }}
+      environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
+
   build-image:
     name: Generate FFOS iso from tags
-    needs: [permission-check, resolve-container]
+    needs: [permission-check, resolve-container, build-ff-player-static]
+    if: always() && !failure() && !cancelled()
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
     container:
@@ -321,20 +333,25 @@ jobs:
           cp -r ffos-user/components/player-wrapper-ui/* /build/archiso-ff1/airootfs/opt/feral/ui/player/
           mkdir -p /build/archiso-ff1/airootfs/home/feralfile/.logs
 
+      - name: Download ff-player static artifact
+        if: ${{ inputs.ff_player_ref != '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ff-player-static
+          path: /tmp/ff-player-static
+
       - name: Install ff-player static bundle
-        if: ${{ inputs.ff_player_bundle_url != '' }}
         run: |
           set -euo pipefail
-          URL="${{ inputs.ff_player_bundle_url }}"
-          STAGE="$(mktemp -d)"
-          trap 'rm -rf "$STAGE"' EXIT
-          curl -fsSL "$URL" | tar -xzf - -C "$STAGE"
-          rm -rf /build/archiso-ff1/airootfs/opt/feral/ff-player
-          mkdir -p /build/archiso-ff1/airootfs/opt/feral/ff-player
-          if [[ -d "$STAGE/out" ]]; then
-            cp -a "$STAGE/out/." /build/archiso-ff1/airootfs/opt/feral/ff-player/
+          DEST=/build/archiso-ff1/airootfs/opt/feral/ff-player
+          rm -rf "$DEST"
+          mkdir -p "$DEST"
+
+          if [ -n "${{ inputs.ff_player_ref }}" ]; then
+            cp -a /tmp/ff-player-static/. "$DEST/"
+            echo "ff-player installed from git ref: ${{ inputs.ff_player_ref }}"
           else
-            cp -a "$STAGE/." /build/archiso-ff1/airootfs/opt/feral/ff-player/
+            echo "Warning: ff_player_ref not provided; ff-player will not be bundled."
           fi
 
       - name: Add Configs and Services

--- a/.github/workflows/build-image-to-cf.yml
+++ b/.github/workflows/build-image-to-cf.yml
@@ -41,6 +41,11 @@ on:
         required: true
         type: string
         default: 'develop'
+      ff_player_ref:
+        description: "ff-player repository reference to build static export"
+        required: true
+        default: "main"
+        type: string
       dev_iso:
         description: "Build development ISO"
         required: true
@@ -66,11 +71,6 @@ on:
         required: true
         type: boolean
         default: false
-      ff_player_bundle_url:
-        description: "Optional: HTTPS URL to ff-player static .tar.gz (gzip). See workflow step for archive layout."
-        required: false
-        default: ""
-
 permissions:
   id-token: write
   contents: read
@@ -107,7 +107,7 @@ jobs:
       environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
       ffos_user_ref: ${{ inputs.ffos_user_ref || github.event.inputs.ffos_user_ref }}
       container_image: ${{ needs.resolve-container.outputs.image }}
-      
+
   build-feral-setupd:
     needs: [permission-check, resolve-container]
     name: Build Feral Setupd
@@ -182,10 +182,22 @@ jobs:
       environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
       container_image: ${{ needs.resolve-container.outputs.image }}
 
+  build-ff-player-static:
+    name: Build ff-player static
+    needs: permission-check
+    if: ${{ inputs.ff_player_ref != '' }}
+    uses: feral-file/ff-player/.github/workflows/build-ff-player-static.yaml@main
+    secrets:
+      REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+    with:
+      ff_player_ref: ${{ inputs.ff_player_ref || github.event.inputs.ff_player_ref }}
+      environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
+
   build-image:
     name: Generate FFOS iso
     runs-on: ubuntu-latest
-    needs: [permission-check, resolve-container, build-feralfile-pacman-repo]
+    needs: [permission-check, resolve-container, build-feralfile-pacman-repo, build-ff-player-static]
+    if: always() && !failure() && !cancelled()
     environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
 
     container:
@@ -226,21 +238,21 @@ jobs:
         run: |
           mkdir -p /build
           cp -r archiso-ff1 /build/
-          
+
           # Create home directory structure
           mkdir -p /build/archiso-ff1/airootfs/home
-          
+
           # Copy user data from ffos-user repository
           cp -r ffos-user/users/feralfile /build/archiso-ff1/airootfs/home/
-          
+
           if [ "${{ inputs.soak-test }}" = "false" ]; then
             # Remove soaktest if not needed
             rm -f /build/archiso-ff1/efiboot/loader/entries/archiso-x86_64-linux-soak-test.conf
             rm -f /build/archiso-ff1/airootfs/usr/local/bin/websocat
-          else 
+          else
             # Copy soaktest user data
             cp -r ffos-user/users/soaktest /build/archiso-ff1/airootfs/home/
-            
+
             cat >> /build/archiso-ff1/packages.x86_64 << EOF
           # soak test tools
           foot
@@ -249,12 +261,12 @@ jobs:
           mesa-utils
           python-rich
           EOF
-          fi 
+          fi
 
           # CRITICAL: Create and set up the mirrorlist for the archiso build environment
           mkdir -p /build/archiso-ff1/pacman.d
           cp /etc/pacman.d/mirrorlist /build/archiso-ff1/pacman.d/mirrorlist
-          
+
           # Also copy mirror list to the final ISO
           mkdir -p /build/archiso-ff1/airootfs/etc/pacman.d
           cp /etc/pacman.d/mirrorlist /build/archiso-ff1/airootfs/etc/pacman.d/mirrorlist
@@ -282,7 +294,7 @@ jobs:
           rust
           base-devel
           EOF
-          
+
           # Configure pacman to not ask for input
           sed -i 's/#NoConfirm/NoConfirm/' /etc/pacman.conf 2>/dev/null || echo "NoConfirm" >> /etc/pacman.conf
 
@@ -291,12 +303,12 @@ jobs:
         run: |
           # Create source directory
           mkdir -p /build/archiso-ff1/airootfs/home/feralfile/src
-          
+
           # Create a file with repository information
           echo "Branch: ${{ github.ref_name }}" > /build/archiso-ff1/airootfs/home/feralfile/src/repo-info.txt
           echo "Version: ${{ inputs.version || github.event.inputs.version }}" >> /build/archiso-ff1/airootfs/home/feralfile/src/repo-info.txt
           echo "Build Date: $(date)" >> /build/archiso-ff1/airootfs/home/feralfile/src/repo-info.txt
-          
+
           # Copy components directory with current checkout
           cp -r ffos-user/components /build/archiso-ff1/airootfs/home/feralfile/src/
 
@@ -326,22 +338,25 @@ jobs:
           cp -r ffos-user/components/player-wrapper-ui/* /build/archiso-ff1/airootfs/opt/feral/ui/player/
           mkdir -p /build/archiso-ff1/airootfs/home/feralfile/.logs
 
+      - name: Download ff-player static artifact
+        if: ${{ inputs.ff_player_ref != '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ff-player-static
+          path: /tmp/ff-player-static
+
       - name: Install ff-player static bundle
-        if: ${{ inputs.ff_player_bundle_url != '' }}
         run: |
           set -euo pipefail
-          URL="${{ inputs.ff_player_bundle_url }}"
-          # Expected: tar.gz of `out/` contents at archive root (index.html, _next/, …), e.g. (cd out && tar -czf ../ff-player-static.tgz .)
-          # Or a single top-level `out/` directory in the archive.
-          STAGE="$(mktemp -d)"
-          trap 'rm -rf "$STAGE"' EXIT
-          curl -fsSL "$URL" | tar -xzf - -C "$STAGE"
-          rm -rf /build/archiso-ff1/airootfs/opt/feral/ff-player
-          mkdir -p /build/archiso-ff1/airootfs/opt/feral/ff-player
-          if [[ -d "$STAGE/out" ]]; then
-            cp -a "$STAGE/out/." /build/archiso-ff1/airootfs/opt/feral/ff-player/
+          DEST=/build/archiso-ff1/airootfs/opt/feral/ff-player
+          rm -rf "$DEST"
+          mkdir -p "$DEST"
+
+          if [ -n "${{ inputs.ff_player_ref }}" ]; then
+            cp -a /tmp/ff-player-static/. "$DEST/"
+            echo "ff-player installed from git ref: ${{ inputs.ff_player_ref }}"
           else
-            cp -a "$STAGE/." /build/archiso-ff1/airootfs/opt/feral/ff-player/
+            echo "Warning: ff_player_ref not provided; ff-player will not be bundled."
           fi
 
       - name: Add Configs and Services
@@ -446,7 +461,7 @@ jobs:
           acl = private
           no_check_bucket = true
           EOF
-      
+
       - name: Configure AWS cred entials (OIDC for KMS)
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -474,7 +489,7 @@ jobs:
             NEW_NAME="FF1${IMAGE_TAG}-${IMAGE_TYPE}${{ inputs.version || github.event.inputs.version }}.iso"
             mv "$ISO_FILE" "/build/out/$NEW_NAME"
             echo "ISO created: /build/out/$NEW_NAME"
-            
+
             cd /build/out
 
             openssl dgst -sha256 -binary "$NEW_NAME" > iso.sha256
@@ -517,14 +532,14 @@ jobs:
       - name: Update version info JSON
         run: |
           set -e
-          
+
           VERSION_INFO_PATH="${{ github.ref_name }}/version-info.json"
           VERSION_INFO_FILE="/tmp/version-info.json"
           CURRENT_VERSION="${{ inputs.version || github.event.inputs.version }}"
           UPDATE_MIN_VERSION="${{ inputs.update_min_version || github.event.inputs.update_min_version }}"
           UPDATE_REQUIRED_VERSION="${{ inputs.update_required_version || github.event.inputs.update_required_version }}"
           UPDATE_RECOVERY_VERSION="${{ inputs.update_recovery_version || github.event.inputs.update_recovery_version }}"
-          
+
           # Try to download existing version info JSON
           if rclone copyto "r2:${{vars.CLOUDFLARE_R2_BUCKET_NAME}}/${VERSION_INFO_PATH}" "$VERSION_INFO_FILE" 2>/dev/null; then
             echo "Downloaded existing version-info.json"
@@ -547,11 +562,11 @@ jobs:
             EXISTING_RUNTIME=""
             echo '{}' > "$VERSION_INFO_FILE"
           fi
-          
+
           # Prepare updated JSON - always update latest_version
           jq --arg latest "$CURRENT_VERSION" '.latest_version = $latest' "$VERSION_INFO_FILE" > "${VERSION_INFO_FILE}.tmp"
           mv "${VERSION_INFO_FILE}.tmp" "$VERSION_INFO_FILE"
-          
+
           # Update min_upgradeable_version if checkbox is checked
           if [ "$UPDATE_REQUIRED_VERSION" = "true" ] || [ "$UPDATE_REQUIRED_VERSION" = true ]; then
             jq --arg upgradeable "$CURRENT_VERSION" '.min_upgradeable_version = $upgradeable' "$VERSION_INFO_FILE" > "${VERSION_INFO_FILE}.tmp"
@@ -563,7 +578,7 @@ jobs:
             mv "${VERSION_INFO_FILE}.tmp" "$VERSION_INFO_FILE"
             echo "Kept existing min_upgradeable_version: $EXISTING_UPGRADEABLE"
           fi
-          
+
           # Update min_runtime_version if checkbox is checked
           if [ "$UPDATE_MIN_VERSION" = "true" ] || [ "$UPDATE_MIN_VERSION" = true ]; then
             jq --arg runtime "$CURRENT_VERSION" '.min_runtime_version = $runtime' "$VERSION_INFO_FILE" > "${VERSION_INFO_FILE}.tmp"
@@ -587,17 +602,17 @@ jobs:
             mv "${VERSION_INFO_FILE}.tmp" "$VERSION_INFO_FILE"
             echo "Kept existing recovery_version: $EXISTING_RECOVERY"
           fi
-          
+
           # Display final JSON
           echo "Final version-info.json:"
           cat "$VERSION_INFO_FILE" | jq .
-          
+
           # Validate final JSON before uploading
           if ! jq empty "$VERSION_INFO_FILE" 2>/dev/null; then
             echo "Error: Generated JSON is invalid"
             exit 1
           fi
-          
+
           # Upload updated JSON to R2
           rclone copyto "$VERSION_INFO_FILE" \
             "r2:${{vars.CLOUDFLARE_R2_BUCKET_NAME}}/${VERSION_INFO_PATH}" \
@@ -607,4 +622,4 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          rm -rf /build 
+          rm -rf /build

--- a/.github/workflows/build-image-to-cf.yml
+++ b/.github/workflows/build-image-to-cf.yml
@@ -66,6 +66,10 @@ on:
         required: true
         type: boolean
         default: false
+      ff_player_bundle_url:
+        description: "Optional: HTTPS URL to ff-player static .tar.gz (gzip). See workflow step for archive layout."
+        required: false
+        default: ""
 
 permissions:
   id-token: write
@@ -321,6 +325,24 @@ jobs:
           mkdir -p /build/archiso-ff1/airootfs/opt/feral/ui/player
           cp -r ffos-user/components/player-wrapper-ui/* /build/archiso-ff1/airootfs/opt/feral/ui/player/
           mkdir -p /build/archiso-ff1/airootfs/home/feralfile/.logs
+
+      - name: Install ff-player static bundle
+        if: ${{ inputs.ff_player_bundle_url != '' }}
+        run: |
+          set -euo pipefail
+          URL="${{ inputs.ff_player_bundle_url }}"
+          # Expected: tar.gz of `out/` contents at archive root (index.html, _next/, …), e.g. (cd out && tar -czf ../ff-player-static.tgz .)
+          # Or a single top-level `out/` directory in the archive.
+          STAGE="$(mktemp -d)"
+          trap 'rm -rf "$STAGE"' EXIT
+          curl -fsSL "$URL" | tar -xzf - -C "$STAGE"
+          rm -rf /build/archiso-ff1/airootfs/opt/feral/ff-player
+          mkdir -p /build/archiso-ff1/airootfs/opt/feral/ff-player
+          if [[ -d "$STAGE/out" ]]; then
+            cp -a "$STAGE/out/." /build/archiso-ff1/airootfs/opt/feral/ff-player/
+          else
+            cp -a "$STAGE/." /build/archiso-ff1/airootfs/opt/feral/ff-player/
+          fi
 
       - name: Add Configs and Services
         run: |

--- a/.github/workflows/pure-build-image-to-cf.yml
+++ b/.github/workflows/pure-build-image-to-cf.yml
@@ -66,6 +66,10 @@ on:
         required: true
         type: boolean
         default: false
+      ff_player_bundle_url:
+        description: "Optional: HTTPS URL to ff-player static .tar.gz (gzip). See workflow step for archive layout."
+        required: false
+        default: ""
 
 permissions:
   id-token: write
@@ -225,6 +229,22 @@ jobs:
           mkdir -p /build/archiso-ff1/airootfs/opt/feral/ui/player
           cp -r ffos-user/components/player-wrapper-ui/* /build/archiso-ff1/airootfs/opt/feral/ui/player/
           mkdir -p /build/archiso-ff1/airootfs/home/feralfile/.logs
+
+      - name: Install ff-player static bundle
+        if: ${{ inputs.ff_player_bundle_url != '' }}
+        run: |
+          set -euo pipefail
+          URL="${{ inputs.ff_player_bundle_url }}"
+          STAGE="$(mktemp -d)"
+          trap 'rm -rf "$STAGE"' EXIT
+          curl -fsSL "$URL" | tar -xzf - -C "$STAGE"
+          rm -rf /build/archiso-ff1/airootfs/opt/feral/ff-player
+          mkdir -p /build/archiso-ff1/airootfs/opt/feral/ff-player
+          if [[ -d "$STAGE/out" ]]; then
+            cp -a "$STAGE/out/." /build/archiso-ff1/airootfs/opt/feral/ff-player/
+          else
+            cp -a "$STAGE/." /build/archiso-ff1/airootfs/opt/feral/ff-player/
+          fi
 
       - name: Add Configs and Services
         run: |

--- a/.github/workflows/pure-build-image-to-cf.yml
+++ b/.github/workflows/pure-build-image-to-cf.yml
@@ -41,6 +41,11 @@ on:
         required: true
         type: string
         default: 'develop'
+      ff_player_ref:
+        description: "ff-player repository reference to build static export"
+        required: true
+        default: "main"
+        type: string
       dev_iso:
         description: "Build development ISO"
         required: true
@@ -66,11 +71,6 @@ on:
         required: true
         type: boolean
         default: false
-      ff_player_bundle_url:
-        description: "Optional: HTTPS URL to ff-player static .tar.gz (gzip). See workflow step for archive layout."
-        required: false
-        default: ""
-
 permissions:
   id-token: write
   contents: read
@@ -86,8 +86,20 @@ jobs:
     with:
       pacman_snapshot: ${{ inputs.pacman_snapshot || github.event.inputs.pacman_snapshot }}
 
+  build-ff-player-static:
+    name: Build ff-player static
+    needs: permission-check
+    if: ${{ inputs.ff_player_ref != '' }}
+    uses: feral-file/ff-player/.github/workflows/build-ff-player-static.yaml@main
+    secrets:
+      REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+    with:
+      ff_player_ref: ${{ inputs.ff_player_ref || github.event.inputs.ff_player_ref }}
+      environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
+
   build-image:
-    needs: [permission-check, resolve-container]
+    needs: [permission-check, resolve-container, build-ff-player-static]
+    if: always() && !failure() && !cancelled()
     name: Generate FFOS iso
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
@@ -130,21 +142,21 @@ jobs:
         run: |
           mkdir -p /build
           cp -r archiso-ff1 /build/
-          
+
           # Create home directory structure
           mkdir -p /build/archiso-ff1/airootfs/home
-          
+
           # Copy user data from ffos-user repository
           cp -r ffos-user/users/feralfile /build/archiso-ff1/airootfs/home/
-          
+
           if [ "${{ inputs.soak-test }}" = "false" ]; then
             # Remove soaktest if not needed
             rm -f /build/archiso-ff1/efiboot/loader/entries/archiso-x86_64-linux-soak-test.conf
             rm -f /build/archiso-ff1/airootfs/usr/local/bin/websocat
-          else 
+          else
             # Copy soaktest user data
             cp -r ffos-user/users/soaktest /build/archiso-ff1/airootfs/home/
-            
+
             cat >> /build/archiso-ff1/packages.x86_64 << EOF
           # soak test tools
           foot
@@ -153,12 +165,12 @@ jobs:
           mesa-utils
           python-rich
           EOF
-          fi 
+          fi
 
           # CRITICAL: Create and set up the mirrorlist for the archiso build environment
           mkdir -p /build/archiso-ff1/pacman.d
           cp /etc/pacman.d/mirrorlist /build/archiso-ff1/pacman.d/mirrorlist
-          
+
           # Also copy mirror list to the final ISO
           mkdir -p /build/archiso-ff1/airootfs/etc/pacman.d
           cp /etc/pacman.d/mirrorlist /build/archiso-ff1/airootfs/etc/pacman.d/mirrorlist
@@ -186,7 +198,7 @@ jobs:
           rust
           base-devel
           EOF
-          
+
           # Configure pacman to not ask for input
           sed -i 's/#NoConfirm/NoConfirm/' /etc/pacman.conf 2>/dev/null || echo "NoConfirm" >> /etc/pacman.conf
 
@@ -195,12 +207,12 @@ jobs:
         run: |
           # Create source directory
           mkdir -p /build/archiso-ff1/airootfs/home/feralfile/src
-          
+
           # Create a file with repository information
           echo "Branch: ${{ github.ref_name }}" > /build/archiso-ff1/airootfs/home/feralfile/src/repo-info.txt
           echo "Version: ${{ inputs.version || github.event.inputs.version }}" >> /build/archiso-ff1/airootfs/home/feralfile/src/repo-info.txt
           echo "Build Date: $(date)" >> /build/archiso-ff1/airootfs/home/feralfile/src/repo-info.txt
-          
+
           # Copy components directory with current checkout
           cp -r ffos-user/components /build/archiso-ff1/airootfs/home/feralfile/src/
 
@@ -230,20 +242,25 @@ jobs:
           cp -r ffos-user/components/player-wrapper-ui/* /build/archiso-ff1/airootfs/opt/feral/ui/player/
           mkdir -p /build/archiso-ff1/airootfs/home/feralfile/.logs
 
+      - name: Download ff-player static artifact
+        if: ${{ inputs.ff_player_ref != '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ff-player-static
+          path: /tmp/ff-player-static
+
       - name: Install ff-player static bundle
-        if: ${{ inputs.ff_player_bundle_url != '' }}
         run: |
           set -euo pipefail
-          URL="${{ inputs.ff_player_bundle_url }}"
-          STAGE="$(mktemp -d)"
-          trap 'rm -rf "$STAGE"' EXIT
-          curl -fsSL "$URL" | tar -xzf - -C "$STAGE"
-          rm -rf /build/archiso-ff1/airootfs/opt/feral/ff-player
-          mkdir -p /build/archiso-ff1/airootfs/opt/feral/ff-player
-          if [[ -d "$STAGE/out" ]]; then
-            cp -a "$STAGE/out/." /build/archiso-ff1/airootfs/opt/feral/ff-player/
+          DEST=/build/archiso-ff1/airootfs/opt/feral/ff-player
+          rm -rf "$DEST"
+          mkdir -p "$DEST"
+
+          if [ -n "${{ inputs.ff_player_ref }}" ]; then
+            cp -a /tmp/ff-player-static/. "$DEST/"
+            echo "ff-player installed from git ref: ${{ inputs.ff_player_ref }}"
           else
-            cp -a "$STAGE/." /build/archiso-ff1/airootfs/opt/feral/ff-player/
+            echo "Warning: ff_player_ref not provided; ff-player will not be bundled."
           fi
 
       - name: Add Configs and Services
@@ -376,7 +393,7 @@ jobs:
             NEW_NAME="FF1${IMAGE_TAG}-${IMAGE_TYPE}${{ inputs.version || github.event.inputs.version }}.iso"
             mv "$ISO_FILE" "/build/out/$NEW_NAME"
             echo "ISO created: /build/out/$NEW_NAME"
-            
+
             cd /build/out
 
             openssl dgst -sha256 -binary "$NEW_NAME" > iso.sha256
@@ -419,14 +436,14 @@ jobs:
       - name: Update version info JSON
         run: |
           set -e
-          
+
           VERSION_INFO_PATH="${{ github.ref_name }}/version-info.json"
           VERSION_INFO_FILE="/tmp/version-info.json"
           CURRENT_VERSION="${{ inputs.version || github.event.inputs.version }}"
           UPDATE_MIN_VERSION="${{ inputs.update_min_version || github.event.inputs.update_min_version }}"
           UPDATE_REQUIRED_VERSION="${{ inputs.update_required_version || github.event.inputs.update_required_version }}"
           UPDATE_RECOVERY_VERSION="${{ inputs.update_recovery_version || github.event.inputs.update_recovery_version }}"
-          
+
           # Try to download existing version info JSON
           if rclone copyto "r2:${{vars.CLOUDFLARE_R2_BUCKET_NAME}}/${VERSION_INFO_PATH}" "$VERSION_INFO_FILE" 2>/dev/null; then
             echo "Downloaded existing version-info.json"
@@ -449,11 +466,11 @@ jobs:
             EXISTING_RUNTIME=""
             echo '{}' > "$VERSION_INFO_FILE"
           fi
-          
+
           # Prepare updated JSON - always update latest_version
           jq --arg latest "$CURRENT_VERSION" '.latest_version = $latest' "$VERSION_INFO_FILE" > "${VERSION_INFO_FILE}.tmp"
           mv "${VERSION_INFO_FILE}.tmp" "$VERSION_INFO_FILE"
-          
+
           # Update min_upgradeable_version if checkbox is checked
           if [ "$UPDATE_REQUIRED_VERSION" = "true" ] || [ "$UPDATE_REQUIRED_VERSION" = true ]; then
             jq --arg upgradeable "$CURRENT_VERSION" '.min_upgradeable_version = $upgradeable' "$VERSION_INFO_FILE" > "${VERSION_INFO_FILE}.tmp"
@@ -465,7 +482,7 @@ jobs:
             mv "${VERSION_INFO_FILE}.tmp" "$VERSION_INFO_FILE"
             echo "Kept existing min_upgradeable_version: $EXISTING_UPGRADEABLE"
           fi
-          
+
           # Update min_runtime_version if checkbox is checked
           if [ "$UPDATE_MIN_VERSION" = "true" ] || [ "$UPDATE_MIN_VERSION" = true ]; then
             jq --arg runtime "$CURRENT_VERSION" '.min_runtime_version = $runtime' "$VERSION_INFO_FILE" > "${VERSION_INFO_FILE}.tmp"
@@ -489,17 +506,17 @@ jobs:
             mv "${VERSION_INFO_FILE}.tmp" "$VERSION_INFO_FILE"
             echo "Kept existing recovery_version: $EXISTING_RECOVERY"
           fi
-          
+
           # Display final JSON
           echo "Final version-info.json:"
           cat "$VERSION_INFO_FILE" | jq .
-          
+
           # Validate final JSON before uploading
           if ! jq empty "$VERSION_INFO_FILE" 2>/dev/null; then
             echo "Error: Generated JSON is invalid"
             exit 1
           fi
-          
+
           # Upload updated JSON to R2
           rclone copyto "$VERSION_INFO_FILE" \
             "r2:${{vars.CLOUDFLARE_R2_BUCKET_NAME}}/${VERSION_INFO_PATH}" \
@@ -509,4 +526,4 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          rm -rf /build 
+          rm -rf /build

--- a/archiso-ff1/packages.x86_64
+++ b/archiso-ff1/packages.x86_64
@@ -71,3 +71,6 @@ feral-controld
 feral-setupd
 feral-sys-monitord
 feral-watchdog
+
+# Local static bundle for ff-player (feral-ff-player-static.service / serve-ff-player-static.sh)
+darkhttpd

--- a/archiso-ff1/packages.x86_64
+++ b/archiso-ff1/packages.x86_64
@@ -66,11 +66,11 @@ intel-gpu-tools
 lm_sensors
 earlyoom
 
-# Feralfile 
+# Feralfile
 feral-controld
 feral-setupd
 feral-sys-monitord
 feral-watchdog
 
-# Local static bundle for ff-player (feral-ff-player-static.service / serve-ff-player-static.sh)
+# Local static bundle for ff-player
 darkhttpd


### PR DESCRIPTION
## Summary

Build the ff-player static export as part of the FFOS image pipeline by calling the reusable workflow in `feral-file/ff-player` (`build-ff-player-static.yaml`), then bundling the artifact into the archiso tree under `/opt/feral/ff-player`.

## Changes

- Add `ff_player_ref` workflow input (alongside `ffos_user_ref`).
- Job `build-ff-player-static` uses cross-repo `uses: feral-file/ff-player/.github/workflows/build-ff-player-static.yaml@…` with `REPO_ACCESS_TOKEN` for checkout.
- Download artifact `ff-player-static` in `build-image` and copy into `airootfs/opt/feral/ff-player`.
- Applied to `build-image-to-cf.yml`, `build-image-from-tags.yml`, and `pure-build-image-to-cf.yml`.

## Tracking

Related to https://github.com/feral-file/feral-file/issues/3397


Made with [Cursor](https://cursor.com)