### PR TITLE
Local player

### DIFF
--- a/.github/workflows/build-feral-player.yaml
+++ b/.github/workflows/build-feral-player.yaml
@@ -1,4 +1,4 @@
-name: 🔒 Build ff-player Package
+name: 🔒 Build feral-player Package
 
 on:
   workflow_call:
@@ -23,10 +23,15 @@ on:
         type: string
         default: 'Development'
       ff_player_ref:
-        description: 'ff-player repository reference'
+        description: 'feral-player repository reference'
         required: true
         type: string
         default: 'main'
+      pacman_snapshot:
+        description: 'Pacman repository snapshot (YYYY/MM/DD) or "latest"'
+        required: false
+        type: string
+        default: 'latest'
       container_image:
         description: 'Container image to use for the pacman build'
         required: true
@@ -54,17 +59,23 @@ permissions:
   contents: read
 
 jobs:
-  build-static:
-    name: Build ff-player static export
+  build-feral-player:
+    name: Build feral-player Package
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
+    container:
+      image: ${{ inputs.container_image }}
 
     steps:
-      - name: Checkout ff-player
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Checkout feral-player
         uses: actions/checkout@v4
         with:
           repository: feral-file/ff-player
           ref: ${{ inputs.ff_player_ref }}
+          path: feral-player
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
 
       - name: Setup Node.js
@@ -72,8 +83,19 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+          cache-dependency-path: feral-player/package-lock.json
+
+      - name: Setup pacman
+        uses: ./.github/actions/setup-pacman
+        with:
+          pacman_snapshot: ${{ inputs.pacman_snapshot }}
+
+      - name: Install build dependencies
+        run: |
+          pacman -S --noconfirm git base-devel shadow fakeroot binutils
 
       - name: Install dependencies
+        working-directory: feral-player
         run: npm ci
 
       - name: Validate required environment variables
@@ -92,6 +114,7 @@ jobs:
           fi
 
       - name: Build static export
+        working-directory: feral-player
         env:
           NEXT_PUBLIC_ENVIRONMENT: ${{ inputs.environment }}
           NEXT_PUBLIC_PUB_DOC_URL: ${{ vars.PUB_DOC_URL }}
@@ -100,38 +123,6 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: npm run build
 
-      - name: Upload static artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ff-player-static
-          path: out/
-          retention-days: 1
-
-  package:
-    name: Package ff-player as pacman package
-    needs: build-static
-    runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
-    container:
-      image: ${{ inputs.container_image }}
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Download static artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ff-player-static
-          path: /tmp/ff-player-static
-
-      - name: Setup pacman
-        uses: ./.github/actions/setup-pacman
-
-      - name: Install build dependencies
-        run: |
-          pacman -S --noconfirm git base-devel shadow fakeroot binutils
-
       - name: Set Version
         run: |
           echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
@@ -139,16 +130,17 @@ jobs:
       - name: Build Pacman Package
         run: |
           set -euo pipefail
-          COMP=ff-player
+          COMP=feral-player
           VER=${VERSION}
           TARBALL="${COMP}_${VER}.tar.gz"
+          FF_PLAYER_OUT="${GITHUB_WORKSPACE}/feral-player/out"
 
-          mkdir -p /tmp/ff-player-pkg
+          mkdir -p /tmp/feral-player-pkg
 
           # Create tarball from the pre-built static export
-          tar czf "/tmp/ff-player-pkg/${TARBALL}" -C /tmp/ff-player-static .
+          tar czf "/tmp/feral-player-pkg/${TARBALL}" -C "${FF_PLAYER_OUT}" .
 
-          cd /tmp/ff-player-pkg
+          cd /tmp/feral-player-pkg
 
           cat <<EOF > PKGBUILD
           # Maintainer: ${{ inputs.maintainer }}
@@ -166,8 +158,8 @@ jobs:
           sha256sums=('SKIP')
 
           package() {
-            install -dm755 "\$pkgdir/opt/feral/ff-player"
-            cp -r "\$srcdir"/. "\$pkgdir/opt/feral/ff-player/"
+            install -dm755 "\$pkgdir/opt/feral/feral-player"
+            cp -r "\$srcdir"/. "\$pkgdir/opt/feral/feral-player/"
           }
           EOF
 
@@ -188,7 +180,7 @@ jobs:
           chmod +x /usr/local/bin/kmspgp
 
       - name: Sign packages with AWS KMS (OpenPGP)
-        working-directory: /tmp/ff-player-pkg
+        working-directory: /tmp/feral-player-pkg
         env:
           KMS_KEY_ID: ${{ secrets.AWS_KMS_FF1_RELEASE_SIGNING_KEY_ID }}
         run: |
@@ -198,7 +190,7 @@ jobs:
           done
 
       - name: Rclone to r2
-        working-directory: /tmp/ff-player-pkg
+        working-directory: /tmp/feral-player-pkg
         run: |
           pacman -S --noconfirm rclone
 
@@ -226,9 +218,9 @@ jobs:
 
       - name: Package Info
         run: |
-          echo "ff-player version ${VERSION} built successfully as pacman package and uploaded to R2"
+          echo "feral-player version ${VERSION} built successfully as pacman package and uploaded to R2"
 
       - name: Cleanup
         if: always()
         run: |
-          rm -rf /tmp/ff-player-pkg /tmp/ff-player-static
+          rm -rf /tmp/feral-player-pkg

--- a/.github/workflows/build-ff-player.yaml
+++ b/.github/workflows/build-ff-player.yaml
@@ -1,0 +1,234 @@
+name: 🔒 Build ff-player Package
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Package version'
+        required: true
+        type: string
+      description:
+        description: 'Package description'
+        required: false
+        type: string
+        default: 'FF Player Static Web Application'
+      maintainer:
+        description: 'Package maintainer'
+        required: false
+        type: string
+        default: 'GitHub Actions'
+      environment:
+        description: 'GitHub Environment name (Development or Production)'
+        required: true
+        type: string
+        default: 'Development'
+      ff_player_ref:
+        description: 'ff-player repository reference'
+        required: true
+        type: string
+        default: 'main'
+      container_image:
+        description: 'Container image to use for the pacman build'
+        required: true
+        type: string
+    secrets:
+      CLOUDFLARE_ACCOUNT_ID:
+        required: true
+      CLOUDFLARE_ACCESS_KEY_ID:
+        required: true
+      CLOUDFLARE_SECRET_ACCESS_KEY:
+        required: true
+      REPO_ACCESS_TOKEN:
+        required: true
+      AWS_KMS_FF1_RELEASE_SIGNER_ROLE_ARN:
+        required: true
+      AWS_KMS_FF1_RELEASE_SIGNING_KEY_ID:
+        required: true
+      SENTRY_AUTH_TOKEN:
+        required: false
+      SENTRY_DSN_PLAYER:
+        required: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build-static:
+    name: Build ff-player static export
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+
+    steps:
+      - name: Checkout ff-player
+        uses: actions/checkout@v4
+        with:
+          repository: feral-file/ff-player
+          ref: ${{ inputs.ff_player_ref }}
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate required environment variables
+        env:
+          NEXT_PUBLIC_ENVIRONMENT: ${{ inputs.environment }}
+          NEXT_PUBLIC_PUB_DOC_URL: ${{ vars.PUB_DOC_URL }}
+          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.SENTRY_DSN_PLAYER }}
+        run: |
+          echo "NEXT_PUBLIC_ENVIRONMENT=${NEXT_PUBLIC_ENVIRONMENT}"
+          echo "NEXT_PUBLIC_PUB_DOC_URL=${NEXT_PUBLIC_PUB_DOC_URL}"
+          echo "NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN}"
+
+          if [ -z "${NEXT_PUBLIC_PUB_DOC_URL}" ]; then
+            echo "::error::Missing required environment variable: NEXT_PUBLIC_PUB_DOC_URL"
+            exit 1
+          fi
+
+      - name: Build static export
+        env:
+          NEXT_PUBLIC_ENVIRONMENT: ${{ inputs.environment }}
+          NEXT_PUBLIC_PUB_DOC_URL: ${{ vars.PUB_DOC_URL }}
+          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.SENTRY_DSN_PLAYER }}
+          NEXT_PUBLIC_DISABLE_VERSION_CHECK: 'true'
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: npm run build
+
+      - name: Upload static artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ff-player-static
+          path: out/
+          retention-days: 1
+
+  package:
+    name: Package ff-player as pacman package
+    needs: build-static
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    container:
+      image: ${{ inputs.container_image }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Download static artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ff-player-static
+          path: /tmp/ff-player-static
+
+      - name: Setup pacman
+        uses: ./.github/actions/setup-pacman
+
+      - name: Install build dependencies
+        run: |
+          pacman -S --noconfirm git base-devel shadow fakeroot binutils
+
+      - name: Set Version
+        run: |
+          echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
+
+      - name: Build Pacman Package
+        run: |
+          set -euo pipefail
+          COMP=ff-player
+          VER=${VERSION}
+          TARBALL="${COMP}_${VER}.tar.gz"
+
+          mkdir -p /tmp/ff-player-pkg
+
+          # Create tarball from the pre-built static export
+          tar czf "/tmp/ff-player-pkg/${TARBALL}" -C /tmp/ff-player-static .
+
+          cd /tmp/ff-player-pkg
+
+          cat <<EOF > PKGBUILD
+          # Maintainer: ${{ inputs.maintainer }}
+          pkgname=${COMP}
+          pkgver=${VER}
+          pkgrel=1
+          pkgdesc="${{ inputs.description }}"
+          arch=('x86_64' 'aarch64')
+          url="https://github.com/feral-file/ff-player"
+          license=('MIT')
+          depends=()
+          options=(!strip)
+
+          source=("${TARBALL}")
+          sha256sums=('SKIP')
+
+          package() {
+            install -dm755 "\$pkgdir/opt/feral/ff-player"
+            cp -r "\$srcdir"/. "\$pkgdir/opt/feral/ff-player/"
+          }
+          EOF
+
+          useradd -m builder || true
+          chown -R builder:builder .
+          su builder -c "makepkg -f --skipinteg"
+
+      - name: Configure AWS credentials (OIDC for KMS)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_KMS_FF1_RELEASE_SIGNER_ROLE_ARN }}
+          aws-region: 'ap-northeast-1'
+
+      - name: Install kmspgp
+        run: |
+          curl -sL -o /usr/local/bin/kmspgp \
+            https://github.com/hf/kmspgp/releases/download/v1.1.0/kmspgp-v1.1.0-linux-amd64
+          chmod +x /usr/local/bin/kmspgp
+
+      - name: Sign packages with AWS KMS (OpenPGP)
+        working-directory: /tmp/ff-player-pkg
+        env:
+          KMS_KEY_ID: ${{ secrets.AWS_KMS_FF1_RELEASE_SIGNING_KEY_ID }}
+        run: |
+          set -euo pipefail
+          for p in *.pkg.tar.zst; do
+            kmspgp sign "$KMS_KEY_ID" < "$p" > "$p.sig"
+          done
+
+      - name: Rclone to r2
+        working-directory: /tmp/ff-player-pkg
+        run: |
+          pacman -S --noconfirm rclone
+
+          mkdir -p ~/.config/rclone
+          cat > ~/.config/rclone/rclone.conf << EOF
+          [r2]
+          type = s3
+          provider = Cloudflare
+          access_key_id = ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
+          secret_access_key = ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
+          endpoint = https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          acl = private
+          no_check_bucket = true
+          EOF
+
+          rclone copy . \
+            "r2:${{vars.CLOUDFLARE_R2_BUCKET_NAME}}/${{ github.ref_name }}/os/x86_64/" \
+            --include="*.pkg.tar.zst" \
+            --include="*.pkg.tar.zst.sig" \
+            --s3-upload-cutoff=100M \
+            --s3-chunk-size=100M \
+            --transfers=7 \
+            --verbose \
+            --stats=1s
+
+      - name: Package Info
+        run: |
+          echo "ff-player version ${VERSION} built successfully as pacman package and uploaded to R2"
+
+      - name: Cleanup
+        if: always()
+        run: |
+          rm -rf /tmp/ff-player-pkg /tmp/ff-player-static

--- a/.github/workflows/build-image-from-tags.yml
+++ b/.github/workflows/build-image-from-tags.yml
@@ -54,6 +54,10 @@ on:
         required: false
         default: true
         type: boolean
+      ff_player_bundle_url:
+        description: "Optional: HTTPS URL to ff-player static .tar.gz (gzip). See workflow step for archive layout."
+        required: false
+        default: ""
 
 permissions:
   id-token: write
@@ -316,6 +320,22 @@ jobs:
           mkdir -p /build/archiso-ff1/airootfs/opt/feral/ui/player
           cp -r ffos-user/components/player-wrapper-ui/* /build/archiso-ff1/airootfs/opt/feral/ui/player/
           mkdir -p /build/archiso-ff1/airootfs/home/feralfile/.logs
+
+      - name: Install ff-player static bundle
+        if: ${{ inputs.ff_player_bundle_url != '' }}
+        run: |
+          set -euo pipefail
+          URL="${{ inputs.ff_player_bundle_url }}"
+          STAGE="$(mktemp -d)"
+          trap 'rm -rf "$STAGE"' EXIT
+          curl -fsSL "$URL" | tar -xzf - -C "$STAGE"
+          rm -rf /build/archiso-ff1/airootfs/opt/feral/ff-player
+          mkdir -p /build/archiso-ff1/airootfs/opt/feral/ff-player
+          if [[ -d "$STAGE/out" ]]; then
+            cp -a "$STAGE/out/." /build/archiso-ff1/airootfs/opt/feral/ff-player/
+          else
+            cp -a "$STAGE/." /build/archiso-ff1/airootfs/opt/feral/ff-player/
+          fi
 
       - name: Add Configs and Services
         run: |

--- a/.github/workflows/build-image-from-tags.yml
+++ b/.github/workflows/build-image-from-tags.yml
@@ -16,9 +16,9 @@ on:
         required: true
         default: "v1.0.1"
       ff_player_ref:
-        description: "ff-player repository reference to build static export"
-        required: true
-        default: "main"
+        description: "Optional feral-player repository reference to build static export"
+        required: false
+        default: ""
         type: string
       soak-test:
         description: "Include soak test"
@@ -70,11 +70,52 @@ jobs:
     with:
       pacman_snapshot: ${{ inputs.pacman_snapshot || github.event.inputs.pacman_snapshot }}
 
-  build-ff-player:
-    name: Build ff-player Package
-    needs: [permission-check, resolve-container]
-    if: ${{ inputs.ff_player_ref != '' }}
-    uses: ./.github/workflows/build-ff-player.yaml
+  determine-local-player:
+    name: Determine Local Player Support
+    needs: permission-check
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - name: Check if ffos tag supports local player
+        id: check
+        env:
+          FFOS_REF: ${{ inputs.ffos_ref || github.event.inputs.ffos_ref }}
+          FF_PLAYER_REF: ${{ inputs.ff_player_ref || github.event.inputs.ff_player_ref }}
+        run: |
+          set -euo pipefail
+
+          MIN_VERSION="1.0.13"
+          REF="${FFOS_REF#refs/tags/}"
+          REF="${REF#v}"
+
+          if [ -z "${FF_PLAYER_REF}" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping local player: ff_player_ref not provided."
+            exit 0
+          fi
+
+          if ! [[ "$REF" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-].*)?$ ]]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping local player: ffos_ref '${FFOS_REF}' is not a supported version tag."
+            exit 0
+          fi
+
+          VERSION="$(printf '%s' "$REF" | grep -Eo '^[0-9]+\.[0-9]+\.[0-9]+')"
+
+          if [ "$(printf '%s\n' "$MIN_VERSION" "$VERSION" | sort -V | head -n1)" = "$MIN_VERSION" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "Local player enabled for ffos_ref ${FFOS_REF}."
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping local player: ffos_ref ${FFOS_REF} is below v${MIN_VERSION}."
+          fi
+
+  build-feral-player:
+    name: Build feral-player Package
+    needs: [permission-check, resolve-container, determine-local-player]
+    if: ${{ needs.determine-local-player.outputs.enabled == 'true' }}
+    uses: ./.github/workflows/build-feral-player.yaml
     secrets:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CLOUDFLARE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
@@ -90,11 +131,12 @@ jobs:
       maintainer: 'Feral File'
       environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
       ff_player_ref: ${{ inputs.ff_player_ref || github.event.inputs.ff_player_ref }}
+      pacman_snapshot: ${{ inputs.pacman_snapshot || github.event.inputs.pacman_snapshot }}
       container_image: ${{ needs.resolve-container.outputs.image }}
 
   build-image:
     name: Generate FFOS iso from tags
-    needs: [permission-check, resolve-container, build-ff-player]
+    needs: [permission-check, resolve-container, determine-local-player, build-feral-player]
     if: always() && !failure() && !cancelled()
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
@@ -141,7 +183,14 @@ jobs:
             git curl rclone wget base-devel jq zip unzip fakeroot binutils openssl aws-cli \
             pacman-contrib shadow go rust cargo
 
-      - name: Build local FFOS component packages (no R2 upload)
+      - name: Download feral-player static artifact
+        if: ${{ needs.determine-local-player.outputs.enabled == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: feral-player-static
+          path: /tmp/feral-player-static
+
+      - name: Build local FFOS packages (no R2 upload)
         env:
           PKG_VERSION: ${{ inputs.version || github.event.inputs.version }}
         run: |
@@ -227,6 +276,40 @@ jobs:
             su builder -c "cd \"$WORKDIR\" && makepkg -f --skipinteg"
             cp ./*.pkg.tar.zst /build/local-repo/x86_64/
           done
+
+          if [ "${{ needs.determine-local-player.outputs.enabled }}" = "true" ]; then
+            PLAYER_PKG_DIR=/tmp/feral-player-pkg
+            PLAYER_TARBALL="feral-player_${PKG_VERSION}.tar.gz"
+
+            rm -rf "$PLAYER_PKG_DIR"
+            mkdir -p "$PLAYER_PKG_DIR"
+            tar czf "$PLAYER_PKG_DIR/$PLAYER_TARBALL" -C /tmp/feral-player-static .
+
+            cd "$PLAYER_PKG_DIR"
+            cat <<EOF > PKGBUILD
+          # Maintainer: GitHub Actions
+          pkgname=feral-player
+          pkgver=${PKG_VERSION}
+          pkgrel=1
+          pkgdesc="FF Player Static Web Application"
+          arch=('x86_64' 'aarch64')
+          url="https://github.com/feral-file/ff-player"
+          license=('MIT')
+          depends=()
+          options=(!strip)
+          source=("${PLAYER_TARBALL}")
+          sha256sums=('SKIP')
+
+          package() {
+            install -dm755 "\$pkgdir/opt/feral/feral-player"
+            cp -r "\$srcdir"/. "\$pkgdir/opt/feral/feral-player/"
+          }
+          EOF
+
+            chown -R builder:builder "$PLAYER_PKG_DIR"
+            su builder -c "cd \"$PLAYER_PKG_DIR\" && makepkg -f --skipinteg"
+            cp ./*.pkg.tar.zst /build/local-repo/x86_64/
+          fi
 
           cd /build/local-repo/x86_64
           repo-add feralfile-local.db.tar.gz ./*.pkg.tar.zst
@@ -340,25 +423,19 @@ jobs:
           cp -r ffos-user/components/player-wrapper-ui/* /build/archiso-ff1/airootfs/opt/feral/ui/player/
           mkdir -p /build/archiso-ff1/airootfs/home/feralfile/.logs
 
-      - name: Download ff-player static artifact
-        if: ${{ inputs.ff_player_ref != '' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: ff-player-static
-          path: /tmp/ff-player-static
-
-      - name: Install ff-player static bundle
+      - name: Install feral-player static bundle
         run: |
           set -euo pipefail
-          DEST=/build/archiso-ff1/airootfs/opt/feral/ff-player
-          rm -rf "$DEST"
-          mkdir -p "$DEST"
+          DEST=/build/archiso-ff1/airootfs/opt/feral/feral-player
 
-          if [ -n "${{ inputs.ff_player_ref }}" ]; then
-            cp -a /tmp/ff-player-static/. "$DEST/"
-            echo "ff-player installed from git ref: ${{ inputs.ff_player_ref }}"
+          if [ "${{ needs.determine-local-player.outputs.enabled }}" = "true" ]; then
+            rm -rf "$DEST"
+            mkdir -p "$DEST"
+            cp -a /tmp/feral-player-static/. "$DEST/"
+            echo "feral-player installed from git ref: ${{ inputs.ff_player_ref }}"
           else
-            echo "Warning: ff_player_ref not provided; ff-player will not be bundled."
+            rm -rf "$DEST"
+            echo "Skipping local player bundle for ffos_ref ${{ inputs.ffos_ref || github.event.inputs.ffos_ref }}."
           fi
 
       - name: Add Configs and Services

--- a/.github/workflows/build-image-from-tags.yml
+++ b/.github/workflows/build-image-from-tags.yml
@@ -70,20 +70,31 @@ jobs:
     with:
       pacman_snapshot: ${{ inputs.pacman_snapshot || github.event.inputs.pacman_snapshot }}
 
-  build-ff-player-static:
-    name: Build ff-player static
-    needs: permission-check
+  build-ff-player:
+    name: Build ff-player Package
+    needs: [permission-check, resolve-container]
     if: ${{ inputs.ff_player_ref != '' }}
-    uses: feral-file/ff-player/.github/workflows/build-ff-player-static.yaml@main
+    uses: ./.github/workflows/build-ff-player.yaml
     secrets:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
+      CLOUDFLARE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
       REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+      AWS_KMS_FF1_RELEASE_SIGNER_ROLE_ARN: ${{ secrets.AWS_KMS_FF1_RELEASE_SIGNER_ROLE_ARN }}
+      AWS_KMS_FF1_RELEASE_SIGNING_KEY_ID: ${{ secrets.AWS_KMS_FF1_RELEASE_SIGNING_KEY_ID }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_DSN_PLAYER: ${{ secrets.SENTRY_DSN_PLAYER }}
     with:
-      ff_player_ref: ${{ inputs.ff_player_ref || github.event.inputs.ff_player_ref }}
+      version: ${{ inputs.version || github.event.inputs.version }}
+      description: 'FF Player Static Web Application'
+      maintainer: 'Feral File'
       environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
+      ff_player_ref: ${{ inputs.ff_player_ref || github.event.inputs.ff_player_ref }}
+      container_image: ${{ needs.resolve-container.outputs.image }}
 
   build-image:
     name: Generate FFOS iso from tags
-    needs: [permission-check, resolve-container, build-ff-player-static]
+    needs: [permission-check, resolve-container, build-ff-player]
     if: always() && !failure() && !cancelled()
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}

--- a/.github/workflows/build-image-from-tags.yml
+++ b/.github/workflows/build-image-from-tags.yml
@@ -15,6 +15,11 @@ on:
         description: "ffos-user git tag/ref to checkout"
         required: true
         default: "v1.0.1"
+      ff_player_ref:
+        description: "ff-player repository reference to build static export"
+        required: true
+        default: "main"
+        type: string
       soak-test:
         description: "Include soak test"
         required: true
@@ -54,11 +59,6 @@ on:
         required: false
         default: true
         type: boolean
-      ff_player_bundle_url:
-        description: "Optional: HTTPS URL to ff-player static .tar.gz (gzip). See workflow step for archive layout."
-        required: false
-        default: ""
-
 permissions:
   id-token: write
   contents: read
@@ -74,9 +74,21 @@ jobs:
     with:
       pacman_snapshot: ${{ inputs.pacman_snapshot || github.event.inputs.pacman_snapshot }}
 
+  build-ff-player-static:
+    name: Build ff-player static
+    needs: permission-check
+    if: ${{ inputs.ff_player_ref != '' }}
+    uses: feral-file/ff-player/.github/workflows/build-ff-player-static.yaml@main
+    secrets:
+      REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+    with:
+      ff_player_ref: ${{ inputs.ff_player_ref || github.event.inputs.ff_player_ref }}
+      environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
+
   build-image:
     name: Generate FFOS iso from tags
-    needs: [permission-check, resolve-container]
+    needs: [permission-check, resolve-container, build-ff-player-static]
+    if: always() && !failure() && !cancelled()
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
     container:
@@ -321,20 +333,25 @@ jobs:
           cp -r ffos-user/components/player-wrapper-ui/* /build/archiso-ff1/airootfs/opt/feral/ui/player/
           mkdir -p /build/archiso-ff1/airootfs/home/feralfile/.logs
 
+      - name: Download ff-player static artifact
+        if: ${{ inputs.ff_player_ref != '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ff-player-static
+          path: /tmp/ff-player-static
+
       - name: Install ff-player static bundle
-        if: ${{ inputs.ff_player_bundle_url != '' }}
         run: |
           set -euo pipefail
-          URL="${{ inputs.ff_player_bundle_url }}"
-          STAGE="$(mktemp -d)"
-          trap 'rm -rf "$STAGE"' EXIT
-          curl -fsSL "$URL" | tar -xzf - -C "$STAGE"
-          rm -rf /build/archiso-ff1/airootfs/opt/feral/ff-player
-          mkdir -p /build/archiso-ff1/airootfs/opt/feral/ff-player
-          if [[ -d "$STAGE/out" ]]; then
-            cp -a "$STAGE/out/." /build/archiso-ff1/airootfs/opt/feral/ff-player/
+          DEST=/build/archiso-ff1/airootfs/opt/feral/ff-player
+          rm -rf "$DEST"
+          mkdir -p "$DEST"
+
+          if [ -n "${{ inputs.ff_player_ref }}" ]; then
+            cp -a /tmp/ff-player-static/. "$DEST/"
+            echo "ff-player installed from git ref: ${{ inputs.ff_player_ref }}"
           else
-            cp -a "$STAGE/." /build/archiso-ff1/airootfs/opt/feral/ff-player/
+            echo "Warning: ff_player_ref not provided; ff-player will not be bundled."
           fi
 
       - name: Add Configs and Services

--- a/.github/workflows/build-image-from-tags.yml
+++ b/.github/workflows/build-image-from-tags.yml
@@ -45,10 +45,6 @@ on:
           - "2025/11/25"
           - "2025/05/31"
           - "latest"
-      webapp_url:
-        description: "Optional: WebApp URL to include in ff1-config.json"
-        required: false
-        default: ""
       dev_iso:
         description: "Build development ISO"
         required: true
@@ -421,7 +417,6 @@ jobs:
           EOF
           chmod 755 /build/archiso-ff1/airootfs/home/feralfile/.config/sys-monitord.json
 
-          WEBAPP_URL="${{ inputs.webapp_url || github.event.inputs.webapp_url }}"
           jq -n \
             --arg branch "${{ github.ref_name }}" \
             --arg version "${{ inputs.version || github.event.inputs.version }}" \
@@ -429,7 +424,6 @@ jobs:
             --arg heartbeat "${{ secrets.HEARTBEAT_ENDPOINT }}" \
             --arg vmagent_url "${{ secrets.VMAGENT_REMOTE_URL }}" \
             --arg vmagent_token "${{ secrets.VMAGENT_REMOTE_BEARER_TOKEN }}" \
-            --arg webapp_url "${WEBAPP_URL}" \
             '{
               branch: $branch,
               version: $version,
@@ -437,7 +431,7 @@ jobs:
               heartbeat_endpoint: $heartbeat,
               vmagent_remote_url: $vmagent_url,
               vmagent_remote_bearer_token: $vmagent_token
-            } + (if $webapp_url != "" then {webapp_url: $webapp_url} else {} end)' \
+            }' \
             > /build/archiso-ff1/airootfs/home/feralfile/ff1-config.json
           chmod 755 /build/archiso-ff1/airootfs/home/feralfile/ff1-config.json
 

--- a/.github/workflows/build-image-to-cf.yml
+++ b/.github/workflows/build-image-to-cf.yml
@@ -32,10 +32,6 @@ on:
           - "2025/11/25"
           - "2025/05/31"
           - "latest"
-      webapp_url:
-        description: "Optional: WebApp URL to include in ff1-config.json"
-        required: false
-        default: ""
       ffos_user_ref:
         description: 'ffos-user repository reference'
         required: true
@@ -417,7 +413,6 @@ jobs:
           EOF
           chmod 755 /build/archiso-ff1/airootfs/home/feralfile/.config/sys-monitord.json
 
-          WEBAPP_URL="${{ inputs.webapp_url || github.event.inputs.webapp_url }}"
           jq -n \
             --arg branch "${{ github.ref_name }}" \
             --arg version "${{ inputs.version || github.event.inputs.version }}" \
@@ -425,7 +420,6 @@ jobs:
             --arg heartbeat "${{ secrets.HEARTBEAT_ENDPOINT }}" \
             --arg vmagent_url "${{ secrets.VMAGENT_REMOTE_URL }}" \
             --arg vmagent_token "${{ secrets.VMAGENT_REMOTE_BEARER_TOKEN }}" \
-            --arg webapp_url "${WEBAPP_URL}" \
             '{
               branch: $branch,
               version: $version,
@@ -433,7 +427,7 @@ jobs:
               heartbeat_endpoint: $heartbeat,
               vmagent_remote_url: $vmagent_url,
               vmagent_remote_bearer_token: $vmagent_token,
-            } + (if $webapp_url != "" then {webapp_url: $webapp_url} else {} end)' \
+            }' \
             > /build/archiso-ff1/airootfs/home/feralfile/ff1-config.json
           chmod 755 /build/archiso-ff1/airootfs/home/feralfile/ff1-config.json
 

--- a/.github/workflows/build-image-to-cf.yml
+++ b/.github/workflows/build-image-to-cf.yml
@@ -41,6 +41,11 @@ on:
         required: true
         type: string
         default: 'develop'
+      ff_player_ref:
+        description: "ff-player repository reference to build static export"
+        required: true
+        default: "main"
+        type: string
       dev_iso:
         description: "Build development ISO"
         required: true
@@ -66,11 +71,6 @@ on:
         required: true
         type: boolean
         default: false
-      ff_player_bundle_url:
-        description: "Optional: HTTPS URL to ff-player static .tar.gz (gzip). See workflow step for archive layout."
-        required: false
-        default: ""
-
 permissions:
   id-token: write
   contents: read
@@ -107,7 +107,7 @@ jobs:
       environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
       ffos_user_ref: ${{ inputs.ffos_user_ref || github.event.inputs.ffos_user_ref }}
       container_image: ${{ needs.resolve-container.outputs.image }}
-      
+
   build-feral-setupd:
     needs: [permission-check, resolve-container]
     name: Build Feral Setupd
@@ -182,10 +182,22 @@ jobs:
       environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
       container_image: ${{ needs.resolve-container.outputs.image }}
 
+  build-ff-player-static:
+    name: Build ff-player static
+    needs: permission-check
+    if: ${{ inputs.ff_player_ref != '' }}
+    uses: feral-file/ff-player/.github/workflows/build-ff-player-static.yaml@main
+    secrets:
+      REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+    with:
+      ff_player_ref: ${{ inputs.ff_player_ref || github.event.inputs.ff_player_ref }}
+      environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
+
   build-image:
     name: Generate FFOS iso
     runs-on: ubuntu-latest
-    needs: [permission-check, resolve-container, build-feralfile-pacman-repo]
+    needs: [permission-check, resolve-container, build-feralfile-pacman-repo, build-ff-player-static]
+    if: always() && !failure() && !cancelled()
     environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
 
     container:
@@ -226,21 +238,21 @@ jobs:
         run: |
           mkdir -p /build
           cp -r archiso-ff1 /build/
-          
+
           # Create home directory structure
           mkdir -p /build/archiso-ff1/airootfs/home
-          
+
           # Copy user data from ffos-user repository
           cp -r ffos-user/users/feralfile /build/archiso-ff1/airootfs/home/
-          
+
           if [ "${{ inputs.soak-test }}" = "false" ]; then
             # Remove soaktest if not needed
             rm -f /build/archiso-ff1/efiboot/loader/entries/archiso-x86_64-linux-soak-test.conf
             rm -f /build/archiso-ff1/airootfs/usr/local/bin/websocat
-          else 
+          else
             # Copy soaktest user data
             cp -r ffos-user/users/soaktest /build/archiso-ff1/airootfs/home/
-            
+
             cat >> /build/archiso-ff1/packages.x86_64 << EOF
           # soak test tools
           foot
@@ -249,12 +261,12 @@ jobs:
           mesa-utils
           python-rich
           EOF
-          fi 
+          fi
 
           # CRITICAL: Create and set up the mirrorlist for the archiso build environment
           mkdir -p /build/archiso-ff1/pacman.d
           cp /etc/pacman.d/mirrorlist /build/archiso-ff1/pacman.d/mirrorlist
-          
+
           # Also copy mirror list to the final ISO
           mkdir -p /build/archiso-ff1/airootfs/etc/pacman.d
           cp /etc/pacman.d/mirrorlist /build/archiso-ff1/airootfs/etc/pacman.d/mirrorlist
@@ -282,7 +294,7 @@ jobs:
           rust
           base-devel
           EOF
-          
+
           # Configure pacman to not ask for input
           sed -i 's/#NoConfirm/NoConfirm/' /etc/pacman.conf 2>/dev/null || echo "NoConfirm" >> /etc/pacman.conf
 
@@ -291,12 +303,12 @@ jobs:
         run: |
           # Create source directory
           mkdir -p /build/archiso-ff1/airootfs/home/feralfile/src
-          
+
           # Create a file with repository information
           echo "Branch: ${{ github.ref_name }}" > /build/archiso-ff1/airootfs/home/feralfile/src/repo-info.txt
           echo "Version: ${{ inputs.version || github.event.inputs.version }}" >> /build/archiso-ff1/airootfs/home/feralfile/src/repo-info.txt
           echo "Build Date: $(date)" >> /build/archiso-ff1/airootfs/home/feralfile/src/repo-info.txt
-          
+
           # Copy components directory with current checkout
           cp -r ffos-user/components /build/archiso-ff1/airootfs/home/feralfile/src/
 
@@ -326,22 +338,25 @@ jobs:
           cp -r ffos-user/components/player-wrapper-ui/* /build/archiso-ff1/airootfs/opt/feral/ui/player/
           mkdir -p /build/archiso-ff1/airootfs/home/feralfile/.logs
 
+      - name: Download ff-player static artifact
+        if: ${{ inputs.ff_player_ref != '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ff-player-static
+          path: /tmp/ff-player-static
+
       - name: Install ff-player static bundle
-        if: ${{ inputs.ff_player_bundle_url != '' }}
         run: |
           set -euo pipefail
-          URL="${{ inputs.ff_player_bundle_url }}"
-          # Expected: tar.gz of `out/` contents at archive root (index.html, _next/, …), e.g. (cd out && tar -czf ../ff-player-static.tgz .)
-          # Or a single top-level `out/` directory in the archive.
-          STAGE="$(mktemp -d)"
-          trap 'rm -rf "$STAGE"' EXIT
-          curl -fsSL "$URL" | tar -xzf - -C "$STAGE"
-          rm -rf /build/archiso-ff1/airootfs/opt/feral/ff-player
-          mkdir -p /build/archiso-ff1/airootfs/opt/feral/ff-player
-          if [[ -d "$STAGE/out" ]]; then
-            cp -a "$STAGE/out/." /build/archiso-ff1/airootfs/opt/feral/ff-player/
+          DEST=/build/archiso-ff1/airootfs/opt/feral/ff-player
+          rm -rf "$DEST"
+          mkdir -p "$DEST"
+
+          if [ -n "${{ inputs.ff_player_ref }}" ]; then
+            cp -a /tmp/ff-player-static/. "$DEST/"
+            echo "ff-player installed from git ref: ${{ inputs.ff_player_ref }}"
           else
-            cp -a "$STAGE/." /build/archiso-ff1/airootfs/opt/feral/ff-player/
+            echo "Warning: ff_player_ref not provided; ff-player will not be bundled."
           fi
 
       - name: Add Configs and Services
@@ -446,7 +461,7 @@ jobs:
           acl = private
           no_check_bucket = true
           EOF
-      
+
       - name: Configure AWS cred entials (OIDC for KMS)
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -474,7 +489,7 @@ jobs:
             NEW_NAME="FF1${IMAGE_TAG}-${IMAGE_TYPE}${{ inputs.version || github.event.inputs.version }}.iso"
             mv "$ISO_FILE" "/build/out/$NEW_NAME"
             echo "ISO created: /build/out/$NEW_NAME"
-            
+
             cd /build/out
 
             openssl dgst -sha256 -binary "$NEW_NAME" > iso.sha256
@@ -517,14 +532,14 @@ jobs:
       - name: Update version info JSON
         run: |
           set -e
-          
+
           VERSION_INFO_PATH="${{ github.ref_name }}/version-info.json"
           VERSION_INFO_FILE="/tmp/version-info.json"
           CURRENT_VERSION="${{ inputs.version || github.event.inputs.version }}"
           UPDATE_MIN_VERSION="${{ inputs.update_min_version || github.event.inputs.update_min_version }}"
           UPDATE_REQUIRED_VERSION="${{ inputs.update_required_version || github.event.inputs.update_required_version }}"
           UPDATE_RECOVERY_VERSION="${{ inputs.update_recovery_version || github.event.inputs.update_recovery_version }}"
-          
+
           # Try to download existing version info JSON
           if rclone copyto "r2:${{vars.CLOUDFLARE_R2_BUCKET_NAME}}/${VERSION_INFO_PATH}" "$VERSION_INFO_FILE" 2>/dev/null; then
             echo "Downloaded existing version-info.json"
@@ -547,11 +562,11 @@ jobs:
             EXISTING_RUNTIME=""
             echo '{}' > "$VERSION_INFO_FILE"
           fi
-          
+
           # Prepare updated JSON - always update latest_version
           jq --arg latest "$CURRENT_VERSION" '.latest_version = $latest' "$VERSION_INFO_FILE" > "${VERSION_INFO_FILE}.tmp"
           mv "${VERSION_INFO_FILE}.tmp" "$VERSION_INFO_FILE"
-          
+
           # Update min_upgradeable_version if checkbox is checked
           if [ "$UPDATE_REQUIRED_VERSION" = "true" ] || [ "$UPDATE_REQUIRED_VERSION" = true ]; then
             jq --arg upgradeable "$CURRENT_VERSION" '.min_upgradeable_version = $upgradeable' "$VERSION_INFO_FILE" > "${VERSION_INFO_FILE}.tmp"
@@ -563,7 +578,7 @@ jobs:
             mv "${VERSION_INFO_FILE}.tmp" "$VERSION_INFO_FILE"
             echo "Kept existing min_upgradeable_version: $EXISTING_UPGRADEABLE"
           fi
-          
+
           # Update min_runtime_version if checkbox is checked
           if [ "$UPDATE_MIN_VERSION" = "true" ] || [ "$UPDATE_MIN_VERSION" = true ]; then
             jq --arg runtime "$CURRENT_VERSION" '.min_runtime_version = $runtime' "$VERSION_INFO_FILE" > "${VERSION_INFO_FILE}.tmp"
@@ -587,17 +602,17 @@ jobs:
             mv "${VERSION_INFO_FILE}.tmp" "$VERSION_INFO_FILE"
             echo "Kept existing recovery_version: $EXISTING_RECOVERY"
           fi
-          
+
           # Display final JSON
           echo "Final version-info.json:"
           cat "$VERSION_INFO_FILE" | jq .
-          
+
           # Validate final JSON before uploading
           if ! jq empty "$VERSION_INFO_FILE" 2>/dev/null; then
             echo "Error: Generated JSON is invalid"
             exit 1
           fi
-          
+
           # Upload updated JSON to R2
           rclone copyto "$VERSION_INFO_FILE" \
             "r2:${{vars.CLOUDFLARE_R2_BUCKET_NAME}}/${VERSION_INFO_PATH}" \
@@ -607,4 +622,4 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          rm -rf /build 
+          rm -rf /build

--- a/.github/workflows/build-image-to-cf.yml
+++ b/.github/workflows/build-image-to-cf.yml
@@ -168,9 +168,30 @@ jobs:
       ffos_user_ref: ${{ inputs.ffos_user_ref || github.event.inputs.ffos_user_ref }}
       container_image: ${{ needs.resolve-container.outputs.image }}
 
+  build-ff-player:
+    needs: [permission-check, resolve-container]
+    name: Build ff-player Package
+    uses: ./.github/workflows/build-ff-player.yaml
+    secrets:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
+      CLOUDFLARE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
+      REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+      AWS_KMS_FF1_RELEASE_SIGNER_ROLE_ARN: ${{ secrets.AWS_KMS_FF1_RELEASE_SIGNER_ROLE_ARN }}
+      AWS_KMS_FF1_RELEASE_SIGNING_KEY_ID: ${{ secrets.AWS_KMS_FF1_RELEASE_SIGNING_KEY_ID }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_DSN_PLAYER: ${{ secrets.SENTRY_DSN_PLAYER }}
+    with:
+      version: ${{ inputs.version || github.event.inputs.version }}
+      description: 'FF Player Static Web Application'
+      maintainer: 'Feral File'
+      environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
+      ff_player_ref: ${{ inputs.ff_player_ref || github.event.inputs.ff_player_ref }}
+      container_image: ${{ needs.resolve-container.outputs.image }}
+
   build-feralfile-pacman-repo:
     name: Build Feralfile pacman repo
-    needs: [permission-check, resolve-container, build-feral-controld, build-feral-setupd, build-feral-sys-monitord, build-feral-watchdog]
+    needs: [permission-check, resolve-container, build-feral-controld, build-feral-setupd, build-feral-sys-monitord, build-feral-watchdog, build-ff-player]
     uses: ./.github/workflows/pacman-repo.yaml
     secrets:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -182,21 +203,10 @@ jobs:
       environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
       container_image: ${{ needs.resolve-container.outputs.image }}
 
-  build-ff-player-static:
-    name: Build ff-player static
-    needs: permission-check
-    if: ${{ inputs.ff_player_ref != '' }}
-    uses: feral-file/ff-player/.github/workflows/build-ff-player-static.yaml@main
-    secrets:
-      REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
-    with:
-      ff_player_ref: ${{ inputs.ff_player_ref || github.event.inputs.ff_player_ref }}
-      environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
-
   build-image:
     name: Generate FFOS iso
     runs-on: ubuntu-latest
-    needs: [permission-check, resolve-container, build-feralfile-pacman-repo, build-ff-player-static]
+    needs: [permission-check, resolve-container, build-feralfile-pacman-repo]
     if: always() && !failure() && !cancelled()
     environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
 
@@ -337,27 +347,6 @@ jobs:
           mkdir -p /build/archiso-ff1/airootfs/opt/feral/ui/player
           cp -r ffos-user/components/player-wrapper-ui/* /build/archiso-ff1/airootfs/opt/feral/ui/player/
           mkdir -p /build/archiso-ff1/airootfs/home/feralfile/.logs
-
-      - name: Download ff-player static artifact
-        if: ${{ inputs.ff_player_ref != '' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: ff-player-static
-          path: /tmp/ff-player-static
-
-      - name: Install ff-player static bundle
-        run: |
-          set -euo pipefail
-          DEST=/build/archiso-ff1/airootfs/opt/feral/ff-player
-          rm -rf "$DEST"
-          mkdir -p "$DEST"
-
-          if [ -n "${{ inputs.ff_player_ref }}" ]; then
-            cp -a /tmp/ff-player-static/. "$DEST/"
-            echo "ff-player installed from git ref: ${{ inputs.ff_player_ref }}"
-          else
-            echo "Warning: ff_player_ref not provided; ff-player will not be bundled."
-          fi
 
       - name: Add Configs and Services
         run: |

--- a/.github/workflows/build-image-to-cf.yml
+++ b/.github/workflows/build-image-to-cf.yml
@@ -38,7 +38,7 @@ on:
         type: string
         default: 'develop'
       ff_player_ref:
-        description: "ff-player repository reference to build static export"
+        description: "feral-player repository reference to build static export"
         required: true
         default: "main"
         type: string
@@ -164,10 +164,10 @@ jobs:
       ffos_user_ref: ${{ inputs.ffos_user_ref || github.event.inputs.ffos_user_ref }}
       container_image: ${{ needs.resolve-container.outputs.image }}
 
-  build-ff-player:
+  build-feral-player:
     needs: [permission-check, resolve-container]
-    name: Build ff-player Package
-    uses: ./.github/workflows/build-ff-player.yaml
+    name: Build feral-player Package
+    uses: ./.github/workflows/build-feral-player.yaml
     secrets:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CLOUDFLARE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
@@ -183,11 +183,12 @@ jobs:
       maintainer: 'Feral File'
       environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
       ff_player_ref: ${{ inputs.ff_player_ref || github.event.inputs.ff_player_ref }}
+      pacman_snapshot: ${{ inputs.pacman_snapshot || github.event.inputs.pacman_snapshot }}
       container_image: ${{ needs.resolve-container.outputs.image }}
 
   build-feralfile-pacman-repo:
     name: Build Feralfile pacman repo
-    needs: [permission-check, resolve-container, build-feral-controld, build-feral-setupd, build-feral-sys-monitord, build-feral-watchdog, build-ff-player]
+    needs: [permission-check, resolve-container, build-feral-controld, build-feral-setupd, build-feral-sys-monitord, build-feral-watchdog, build-feral-player]
     uses: ./.github/workflows/pacman-repo.yaml
     secrets:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -197,6 +198,7 @@ jobs:
       AWS_KMS_FF1_RELEASE_SIGNING_KEY_ID: ${{ secrets.AWS_KMS_FF1_RELEASE_SIGNING_KEY_ID }}
     with:
       environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
+      pacman_snapshot: ${{ inputs.pacman_snapshot || github.event.inputs.pacman_snapshot }}
       container_image: ${{ needs.resolve-container.outputs.image }}
 
   build-image:

--- a/.github/workflows/build-image-to-cf.yml
+++ b/.github/workflows/build-image-to-cf.yml
@@ -66,6 +66,10 @@ on:
         required: true
         type: boolean
         default: false
+      ff_player_bundle_url:
+        description: "Optional: HTTPS URL to ff-player static .tar.gz (gzip). See workflow step for archive layout."
+        required: false
+        default: ""
 
 permissions:
   id-token: write
@@ -321,6 +325,24 @@ jobs:
           mkdir -p /build/archiso-ff1/airootfs/opt/feral/ui/player
           cp -r ffos-user/components/player-wrapper-ui/* /build/archiso-ff1/airootfs/opt/feral/ui/player/
           mkdir -p /build/archiso-ff1/airootfs/home/feralfile/.logs
+
+      - name: Install ff-player static bundle
+        if: ${{ inputs.ff_player_bundle_url != '' }}
+        run: |
+          set -euo pipefail
+          URL="${{ inputs.ff_player_bundle_url }}"
+          # Expected: tar.gz of `out/` contents at archive root (index.html, _next/, …), e.g. (cd out && tar -czf ../ff-player-static.tgz .)
+          # Or a single top-level `out/` directory in the archive.
+          STAGE="$(mktemp -d)"
+          trap 'rm -rf "$STAGE"' EXIT
+          curl -fsSL "$URL" | tar -xzf - -C "$STAGE"
+          rm -rf /build/archiso-ff1/airootfs/opt/feral/ff-player
+          mkdir -p /build/archiso-ff1/airootfs/opt/feral/ff-player
+          if [[ -d "$STAGE/out" ]]; then
+            cp -a "$STAGE/out/." /build/archiso-ff1/airootfs/opt/feral/ff-player/
+          else
+            cp -a "$STAGE/." /build/archiso-ff1/airootfs/opt/feral/ff-player/
+          fi
 
       - name: Add Configs and Services
         run: |

--- a/.github/workflows/manual-build-feral-player.yaml
+++ b/.github/workflows/manual-build-feral-player.yaml
@@ -1,0 +1,222 @@
+name: ▶️ Manual Build Local Player Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Package version'
+        required: true
+        type: string
+      environment:
+        description: "Environment to build"
+        required: true
+        default: "Development"
+        type: choice
+        options:
+          - Development
+          - Production
+      maintainer:
+        description: 'Package maintainer'
+        required: false
+        type: string
+        default: 'GitHub Actions'
+      description:
+        description: 'Package description'
+        required: false
+        type: string
+        default: 'FF Player Static Web Application'
+      ff_player_ref:
+        description: 'ff-player repository reference'
+        required: true
+        type: string
+        default: 'main'
+      pacman_snapshot:
+        description: "Pacman repository snapshot to use"
+        required: false
+        default: "2025/11/25"
+        type: choice
+        options:
+          - "2025/11/25"
+          - "2025/05/31"
+          - "latest"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  permission-check:
+    name: Permission Check
+    uses: ./.github/workflows/permission-check.yaml
+
+  resolve-container:
+    needs: permission-check
+    uses: ./.github/workflows/resolve-container.yaml
+    with:
+      pacman_snapshot: ${{ inputs.pacman_snapshot || github.event.inputs.pacman_snapshot }}
+
+  build-ff-player:
+    name: Build ff-player Package
+    needs: [permission-check, resolve-container]
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
+    container:
+      image: ${{ needs.resolve-container.outputs.image }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Checkout ff-player
+        uses: actions/checkout@v4
+        with:
+          repository: feral-file/ff-player
+          ref: ${{ inputs.ff_player_ref || github.event.inputs.ff_player_ref }}
+          path: ff-player
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: ff-player/package-lock.json
+
+      - name: Setup pacman
+        uses: ./.github/actions/setup-pacman
+        with:
+          pacman_snapshot: ${{ inputs.pacman_snapshot || github.event.inputs.pacman_snapshot }}
+
+      - name: Install build dependencies
+        run: |
+          pacman -S --noconfirm git base-devel shadow fakeroot binutils
+
+      - name: Install dependencies
+        working-directory: ff-player
+        run: npm ci
+
+      - name: Validate required environment variables
+        env:
+          NEXT_PUBLIC_ENVIRONMENT: ${{ inputs.environment || github.event.inputs.environment }}
+          NEXT_PUBLIC_PUB_DOC_URL: ${{ vars.PUB_DOC_URL }}
+          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.SENTRY_DSN_PLAYER }}
+        run: |
+          echo "NEXT_PUBLIC_ENVIRONMENT=${NEXT_PUBLIC_ENVIRONMENT}"
+          echo "NEXT_PUBLIC_PUB_DOC_URL=${NEXT_PUBLIC_PUB_DOC_URL}"
+          echo "NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN}"
+
+          if [ -z "${NEXT_PUBLIC_PUB_DOC_URL}" ]; then
+            echo "::error::Missing required environment variable: NEXT_PUBLIC_PUB_DOC_URL"
+            exit 1
+          fi
+
+      - name: Build static export
+        working-directory: ff-player
+        env:
+          NEXT_PUBLIC_ENVIRONMENT: ${{ inputs.environment || github.event.inputs.environment }}
+          NEXT_PUBLIC_PUB_DOC_URL: ${{ vars.PUB_DOC_URL }}
+          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.SENTRY_DSN_PLAYER }}
+          NEXT_PUBLIC_DISABLE_VERSION_CHECK: 'true'
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: npm run build
+
+      - name: Set Version
+        run: |
+          echo "VERSION=${{ inputs.version || github.event.inputs.version }}" >> $GITHUB_ENV
+
+      - name: Build Pacman Package
+        run: |
+          set -euo pipefail
+          COMP=ff-player
+          VER=${VERSION}
+          TARBALL="${COMP}_${VER}.tar.gz"
+          FF_PLAYER_OUT="${GITHUB_WORKSPACE}/ff-player/out"
+
+          mkdir -p /tmp/ff-player-pkg
+
+          tar czf "/tmp/ff-player-pkg/${TARBALL}" -C "${FF_PLAYER_OUT}" .
+
+          cd /tmp/ff-player-pkg
+
+          cat <<EOF > PKGBUILD
+          # Maintainer: ${{ inputs.maintainer || github.event.inputs.maintainer }}
+          pkgname=${COMP}
+          pkgver=${VER}
+          pkgrel=1
+          pkgdesc="${{ inputs.description || github.event.inputs.description }}"
+          arch=('x86_64' 'aarch64')
+          url="https://github.com/feral-file/ff-player"
+          license=('MIT')
+          depends=()
+          options=(!strip)
+
+          source=("${TARBALL}")
+          sha256sums=('SKIP')
+
+          package() {
+            install -dm755 "\$pkgdir/opt/feral/feral-player"
+            cp -r "\$srcdir"/. "\$pkgdir/opt/feral/feral-player/"
+          }
+          EOF
+
+          useradd -m builder || true
+          chown -R builder:builder .
+          su builder -c "makepkg -f --skipinteg"
+
+      - name: Configure AWS credentials (OIDC for KMS)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_KMS_FF1_RELEASE_SIGNER_ROLE_ARN }}
+          aws-region: 'ap-northeast-1'
+
+      - name: Install kmspgp
+        run: |
+          curl -sL -o /usr/local/bin/kmspgp \
+            https://github.com/hf/kmspgp/releases/download/v1.1.0/kmspgp-v1.1.0-linux-amd64
+          chmod +x /usr/local/bin/kmspgp
+
+      - name: Sign packages with AWS KMS (OpenPGP)
+        working-directory: /tmp/ff-player-pkg
+        env:
+          KMS_KEY_ID: ${{ secrets.AWS_KMS_FF1_RELEASE_SIGNING_KEY_ID }}
+        run: |
+          set -euo pipefail
+          for p in *.pkg.tar.zst; do
+            kmspgp sign "$KMS_KEY_ID" < "$p" > "$p.sig"
+          done
+
+      - name: Rclone to r2
+        working-directory: /tmp/ff-player-pkg
+        run: |
+          pacman -S --noconfirm rclone
+
+          mkdir -p ~/.config/rclone
+          cat > ~/.config/rclone/rclone.conf << EOF
+          [r2]
+          type = s3
+          provider = Cloudflare
+          access_key_id = ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
+          secret_access_key = ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
+          endpoint = https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          acl = private
+          no_check_bucket = true
+          EOF
+
+          rclone copy . \
+            "r2:${{vars.CLOUDFLARE_R2_BUCKET_NAME}}/${{ github.ref_name }}/os/x86_64/" \
+            --include="*.pkg.tar.zst" \
+            --include="*.pkg.tar.zst.sig" \
+            --s3-upload-cutoff=100M \
+            --s3-chunk-size=100M \
+            --transfers=7 \
+            --verbose \
+            --stats=1s
+
+      - name: Package Info
+        run: |
+          echo "ff-player version ${VERSION} built successfully as pacman package and uploaded to R2"
+
+      - name: Cleanup
+        if: always()
+        run: |
+          rm -rf /tmp/ff-player-pkg

--- a/.github/workflows/pacman-repo.yaml
+++ b/.github/workflows/pacman-repo.yaml
@@ -8,6 +8,11 @@ on:
         required: true
         type: string
         default: 'Development'
+      pacman_snapshot:
+        description: 'Pacman repository snapshot to use'
+        required: false
+        type: string
+        default: 'latest'
       container_image:
         description: 'Container image to use for the build'
         required: true
@@ -135,4 +140,4 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          rm -rf repo 
+          rm -rf repo

--- a/.github/workflows/pure-build-image-to-cf.yml
+++ b/.github/workflows/pure-build-image-to-cf.yml
@@ -38,7 +38,7 @@ on:
         type: string
         default: 'develop'
       ff_player_ref:
-        description: "ff-player repository reference to build static export"
+        description: "feral-player repository reference to build static export"
         required: true
         default: "main"
         type: string
@@ -82,11 +82,11 @@ jobs:
     with:
       pacman_snapshot: ${{ inputs.pacman_snapshot || github.event.inputs.pacman_snapshot }}
 
-  build-ff-player:
-    name: Build ff-player Package
+  build-feral-player:
+    name: Build feral-player Package
     needs: [permission-check, resolve-container]
     if: ${{ inputs.ff_player_ref != '' }}
-    uses: ./.github/workflows/build-ff-player.yaml
+    uses: ./.github/workflows/build-feral-player.yaml
     secrets:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CLOUDFLARE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
@@ -102,10 +102,11 @@ jobs:
       maintainer: 'Feral File'
       environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
       ff_player_ref: ${{ inputs.ff_player_ref || github.event.inputs.ff_player_ref }}
+      pacman_snapshot: ${{ inputs.pacman_snapshot || github.event.inputs.pacman_snapshot }}
       container_image: ${{ needs.resolve-container.outputs.image }}
 
   build-image:
-    needs: [permission-check, resolve-container, build-ff-player]
+    needs: [permission-check, resolve-container, build-feral-player]
     if: always() && !failure() && !cancelled()
     name: Generate FFOS iso
     runs-on: ubuntu-latest
@@ -248,27 +249,6 @@ jobs:
           mkdir -p /build/archiso-ff1/airootfs/opt/feral/ui/player
           cp -r ffos-user/components/player-wrapper-ui/* /build/archiso-ff1/airootfs/opt/feral/ui/player/
           mkdir -p /build/archiso-ff1/airootfs/home/feralfile/.logs
-
-      - name: Download ff-player static artifact
-        if: ${{ inputs.ff_player_ref != '' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: ff-player-static
-          path: /tmp/ff-player-static
-
-      - name: Install ff-player static bundle
-        run: |
-          set -euo pipefail
-          DEST=/build/archiso-ff1/airootfs/opt/feral/ff-player
-          rm -rf "$DEST"
-          mkdir -p "$DEST"
-
-          if [ -n "${{ inputs.ff_player_ref }}" ]; then
-            cp -a /tmp/ff-player-static/. "$DEST/"
-            echo "ff-player installed from git ref: ${{ inputs.ff_player_ref }}"
-          else
-            echo "Warning: ff_player_ref not provided; ff-player will not be bundled."
-          fi
 
       - name: Add Configs and Services
         run: |

--- a/.github/workflows/pure-build-image-to-cf.yml
+++ b/.github/workflows/pure-build-image-to-cf.yml
@@ -82,19 +82,30 @@ jobs:
     with:
       pacman_snapshot: ${{ inputs.pacman_snapshot || github.event.inputs.pacman_snapshot }}
 
-  build-ff-player-static:
-    name: Build ff-player static
-    needs: permission-check
+  build-ff-player:
+    name: Build ff-player Package
+    needs: [permission-check, resolve-container]
     if: ${{ inputs.ff_player_ref != '' }}
-    uses: feral-file/ff-player/.github/workflows/build-ff-player-static.yaml@main
+    uses: ./.github/workflows/build-ff-player.yaml
     secrets:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
+      CLOUDFLARE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
       REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+      AWS_KMS_FF1_RELEASE_SIGNER_ROLE_ARN: ${{ secrets.AWS_KMS_FF1_RELEASE_SIGNER_ROLE_ARN }}
+      AWS_KMS_FF1_RELEASE_SIGNING_KEY_ID: ${{ secrets.AWS_KMS_FF1_RELEASE_SIGNING_KEY_ID }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_DSN_PLAYER: ${{ secrets.SENTRY_DSN_PLAYER }}
     with:
-      ff_player_ref: ${{ inputs.ff_player_ref || github.event.inputs.ff_player_ref }}
+      version: ${{ inputs.version || github.event.inputs.version }}
+      description: 'FF Player Static Web Application'
+      maintainer: 'Feral File'
       environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
+      ff_player_ref: ${{ inputs.ff_player_ref || github.event.inputs.ff_player_ref }}
+      container_image: ${{ needs.resolve-container.outputs.image }}
 
   build-image:
-    needs: [permission-check, resolve-container, build-ff-player-static]
+    needs: [permission-check, resolve-container, build-ff-player]
     if: always() && !failure() && !cancelled()
     name: Generate FFOS iso
     runs-on: ubuntu-latest

--- a/.github/workflows/pure-build-image-to-cf.yml
+++ b/.github/workflows/pure-build-image-to-cf.yml
@@ -32,10 +32,6 @@ on:
           - "2025/11/25"
           - "2025/05/31"
           - "latest"
-      webapp_url:
-        description: "Optional: WebApp URL to include in ff1-config.json"
-        required: false
-        default: ""
       ffos_user_ref:
         description: 'ffos-user repository reference'
         required: true
@@ -332,7 +328,6 @@ jobs:
           EOF
           chmod 755 /build/archiso-ff1/airootfs/home/feralfile/.config/sys-monitord.json
 
-          WEBAPP_URL="${{ inputs.webapp_url || github.event.inputs.webapp_url }}"
           jq -n \
             --arg branch "${{ github.ref_name }}" \
             --arg version "${{ inputs.version || github.event.inputs.version }}" \
@@ -340,7 +335,6 @@ jobs:
             --arg heartbeat "${{ secrets.HEARTBEAT_ENDPOINT }}" \
             --arg vmagent_url "${{ secrets.VMAGENT_REMOTE_URL }}" \
             --arg vmagent_token "${{ secrets.VMAGENT_REMOTE_BEARER_TOKEN }}" \
-            --arg webapp_url "${WEBAPP_URL}" \
             '{
               branch: $branch,
               version: $version,
@@ -348,7 +342,7 @@ jobs:
               heartbeat_endpoint: $heartbeat,
               vmagent_remote_url: $vmagent_url,
               vmagent_remote_bearer_token: $vmagent_token,
-            } + (if $webapp_url != "" then {webapp_url: $webapp_url} else {} end)' \
+            }' \
             > /build/archiso-ff1/airootfs/home/feralfile/ff1-config.json
           chmod 755 /build/archiso-ff1/airootfs/home/feralfile/ff1-config.json
 

--- a/.github/workflows/pure-build-image-to-cf.yml
+++ b/.github/workflows/pure-build-image-to-cf.yml
@@ -66,6 +66,10 @@ on:
         required: true
         type: boolean
         default: false
+      ff_player_bundle_url:
+        description: "Optional: HTTPS URL to ff-player static .tar.gz (gzip). See workflow step for archive layout."
+        required: false
+        default: ""
 
 permissions:
   id-token: write
@@ -225,6 +229,22 @@ jobs:
           mkdir -p /build/archiso-ff1/airootfs/opt/feral/ui/player
           cp -r ffos-user/components/player-wrapper-ui/* /build/archiso-ff1/airootfs/opt/feral/ui/player/
           mkdir -p /build/archiso-ff1/airootfs/home/feralfile/.logs
+
+      - name: Install ff-player static bundle
+        if: ${{ inputs.ff_player_bundle_url != '' }}
+        run: |
+          set -euo pipefail
+          URL="${{ inputs.ff_player_bundle_url }}"
+          STAGE="$(mktemp -d)"
+          trap 'rm -rf "$STAGE"' EXIT
+          curl -fsSL "$URL" | tar -xzf - -C "$STAGE"
+          rm -rf /build/archiso-ff1/airootfs/opt/feral/ff-player
+          mkdir -p /build/archiso-ff1/airootfs/opt/feral/ff-player
+          if [[ -d "$STAGE/out" ]]; then
+            cp -a "$STAGE/out/." /build/archiso-ff1/airootfs/opt/feral/ff-player/
+          else
+            cp -a "$STAGE/." /build/archiso-ff1/airootfs/opt/feral/ff-player/
+          fi
 
       - name: Add Configs and Services
         run: |

--- a/.github/workflows/pure-build-image-to-cf.yml
+++ b/.github/workflows/pure-build-image-to-cf.yml
@@ -41,6 +41,11 @@ on:
         required: true
         type: string
         default: 'develop'
+      ff_player_ref:
+        description: "ff-player repository reference to build static export"
+        required: true
+        default: "main"
+        type: string
       dev_iso:
         description: "Build development ISO"
         required: true
@@ -66,11 +71,6 @@ on:
         required: true
         type: boolean
         default: false
-      ff_player_bundle_url:
-        description: "Optional: HTTPS URL to ff-player static .tar.gz (gzip). See workflow step for archive layout."
-        required: false
-        default: ""
-
 permissions:
   id-token: write
   contents: read
@@ -86,8 +86,20 @@ jobs:
     with:
       pacman_snapshot: ${{ inputs.pacman_snapshot || github.event.inputs.pacman_snapshot }}
 
+  build-ff-player-static:
+    name: Build ff-player static
+    needs: permission-check
+    if: ${{ inputs.ff_player_ref != '' }}
+    uses: feral-file/ff-player/.github/workflows/build-ff-player-static.yaml@main
+    secrets:
+      REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+    with:
+      ff_player_ref: ${{ inputs.ff_player_ref || github.event.inputs.ff_player_ref }}
+      environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
+
   build-image:
-    needs: [permission-check, resolve-container]
+    needs: [permission-check, resolve-container, build-ff-player-static]
+    if: always() && !failure() && !cancelled()
     name: Generate FFOS iso
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
@@ -130,21 +142,21 @@ jobs:
         run: |
           mkdir -p /build
           cp -r archiso-ff1 /build/
-          
+
           # Create home directory structure
           mkdir -p /build/archiso-ff1/airootfs/home
-          
+
           # Copy user data from ffos-user repository
           cp -r ffos-user/users/feralfile /build/archiso-ff1/airootfs/home/
-          
+
           if [ "${{ inputs.soak-test }}" = "false" ]; then
             # Remove soaktest if not needed
             rm -f /build/archiso-ff1/efiboot/loader/entries/archiso-x86_64-linux-soak-test.conf
             rm -f /build/archiso-ff1/airootfs/usr/local/bin/websocat
-          else 
+          else
             # Copy soaktest user data
             cp -r ffos-user/users/soaktest /build/archiso-ff1/airootfs/home/
-            
+
             cat >> /build/archiso-ff1/packages.x86_64 << EOF
           # soak test tools
           foot
@@ -153,12 +165,12 @@ jobs:
           mesa-utils
           python-rich
           EOF
-          fi 
+          fi
 
           # CRITICAL: Create and set up the mirrorlist for the archiso build environment
           mkdir -p /build/archiso-ff1/pacman.d
           cp /etc/pacman.d/mirrorlist /build/archiso-ff1/pacman.d/mirrorlist
-          
+
           # Also copy mirror list to the final ISO
           mkdir -p /build/archiso-ff1/airootfs/etc/pacman.d
           cp /etc/pacman.d/mirrorlist /build/archiso-ff1/airootfs/etc/pacman.d/mirrorlist
@@ -186,7 +198,7 @@ jobs:
           rust
           base-devel
           EOF
-          
+
           # Configure pacman to not ask for input
           sed -i 's/#NoConfirm/NoConfirm/' /etc/pacman.conf 2>/dev/null || echo "NoConfirm" >> /etc/pacman.conf
 
@@ -195,12 +207,12 @@ jobs:
         run: |
           # Create source directory
           mkdir -p /build/archiso-ff1/airootfs/home/feralfile/src
-          
+
           # Create a file with repository information
           echo "Branch: ${{ github.ref_name }}" > /build/archiso-ff1/airootfs/home/feralfile/src/repo-info.txt
           echo "Version: ${{ inputs.version || github.event.inputs.version }}" >> /build/archiso-ff1/airootfs/home/feralfile/src/repo-info.txt
           echo "Build Date: $(date)" >> /build/archiso-ff1/airootfs/home/feralfile/src/repo-info.txt
-          
+
           # Copy components directory with current checkout
           cp -r ffos-user/components /build/archiso-ff1/airootfs/home/feralfile/src/
 
@@ -230,20 +242,25 @@ jobs:
           cp -r ffos-user/components/player-wrapper-ui/* /build/archiso-ff1/airootfs/opt/feral/ui/player/
           mkdir -p /build/archiso-ff1/airootfs/home/feralfile/.logs
 
+      - name: Download ff-player static artifact
+        if: ${{ inputs.ff_player_ref != '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ff-player-static
+          path: /tmp/ff-player-static
+
       - name: Install ff-player static bundle
-        if: ${{ inputs.ff_player_bundle_url != '' }}
         run: |
           set -euo pipefail
-          URL="${{ inputs.ff_player_bundle_url }}"
-          STAGE="$(mktemp -d)"
-          trap 'rm -rf "$STAGE"' EXIT
-          curl -fsSL "$URL" | tar -xzf - -C "$STAGE"
-          rm -rf /build/archiso-ff1/airootfs/opt/feral/ff-player
-          mkdir -p /build/archiso-ff1/airootfs/opt/feral/ff-player
-          if [[ -d "$STAGE/out" ]]; then
-            cp -a "$STAGE/out/." /build/archiso-ff1/airootfs/opt/feral/ff-player/
+          DEST=/build/archiso-ff1/airootfs/opt/feral/ff-player
+          rm -rf "$DEST"
+          mkdir -p "$DEST"
+
+          if [ -n "${{ inputs.ff_player_ref }}" ]; then
+            cp -a /tmp/ff-player-static/. "$DEST/"
+            echo "ff-player installed from git ref: ${{ inputs.ff_player_ref }}"
           else
-            cp -a "$STAGE/." /build/archiso-ff1/airootfs/opt/feral/ff-player/
+            echo "Warning: ff_player_ref not provided; ff-player will not be bundled."
           fi
 
       - name: Add Configs and Services
@@ -376,7 +393,7 @@ jobs:
             NEW_NAME="FF1${IMAGE_TAG}-${IMAGE_TYPE}${{ inputs.version || github.event.inputs.version }}.iso"
             mv "$ISO_FILE" "/build/out/$NEW_NAME"
             echo "ISO created: /build/out/$NEW_NAME"
-            
+
             cd /build/out
 
             openssl dgst -sha256 -binary "$NEW_NAME" > iso.sha256
@@ -419,14 +436,14 @@ jobs:
       - name: Update version info JSON
         run: |
           set -e
-          
+
           VERSION_INFO_PATH="${{ github.ref_name }}/version-info.json"
           VERSION_INFO_FILE="/tmp/version-info.json"
           CURRENT_VERSION="${{ inputs.version || github.event.inputs.version }}"
           UPDATE_MIN_VERSION="${{ inputs.update_min_version || github.event.inputs.update_min_version }}"
           UPDATE_REQUIRED_VERSION="${{ inputs.update_required_version || github.event.inputs.update_required_version }}"
           UPDATE_RECOVERY_VERSION="${{ inputs.update_recovery_version || github.event.inputs.update_recovery_version }}"
-          
+
           # Try to download existing version info JSON
           if rclone copyto "r2:${{vars.CLOUDFLARE_R2_BUCKET_NAME}}/${VERSION_INFO_PATH}" "$VERSION_INFO_FILE" 2>/dev/null; then
             echo "Downloaded existing version-info.json"
@@ -449,11 +466,11 @@ jobs:
             EXISTING_RUNTIME=""
             echo '{}' > "$VERSION_INFO_FILE"
           fi
-          
+
           # Prepare updated JSON - always update latest_version
           jq --arg latest "$CURRENT_VERSION" '.latest_version = $latest' "$VERSION_INFO_FILE" > "${VERSION_INFO_FILE}.tmp"
           mv "${VERSION_INFO_FILE}.tmp" "$VERSION_INFO_FILE"
-          
+
           # Update min_upgradeable_version if checkbox is checked
           if [ "$UPDATE_REQUIRED_VERSION" = "true" ] || [ "$UPDATE_REQUIRED_VERSION" = true ]; then
             jq --arg upgradeable "$CURRENT_VERSION" '.min_upgradeable_version = $upgradeable' "$VERSION_INFO_FILE" > "${VERSION_INFO_FILE}.tmp"
@@ -465,7 +482,7 @@ jobs:
             mv "${VERSION_INFO_FILE}.tmp" "$VERSION_INFO_FILE"
             echo "Kept existing min_upgradeable_version: $EXISTING_UPGRADEABLE"
           fi
-          
+
           # Update min_runtime_version if checkbox is checked
           if [ "$UPDATE_MIN_VERSION" = "true" ] || [ "$UPDATE_MIN_VERSION" = true ]; then
             jq --arg runtime "$CURRENT_VERSION" '.min_runtime_version = $runtime' "$VERSION_INFO_FILE" > "${VERSION_INFO_FILE}.tmp"
@@ -489,17 +506,17 @@ jobs:
             mv "${VERSION_INFO_FILE}.tmp" "$VERSION_INFO_FILE"
             echo "Kept existing recovery_version: $EXISTING_RECOVERY"
           fi
-          
+
           # Display final JSON
           echo "Final version-info.json:"
           cat "$VERSION_INFO_FILE" | jq .
-          
+
           # Validate final JSON before uploading
           if ! jq empty "$VERSION_INFO_FILE" 2>/dev/null; then
             echo "Error: Generated JSON is invalid"
             exit 1
           fi
-          
+
           # Upload updated JSON to R2
           rclone copyto "$VERSION_INFO_FILE" \
             "r2:${{vars.CLOUDFLARE_R2_BUCKET_NAME}}/${VERSION_INFO_PATH}" \
@@ -509,4 +526,4 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          rm -rf /build 
+          rm -rf /build

--- a/archiso-ff1/packages.x86_64
+++ b/archiso-ff1/packages.x86_64
@@ -71,3 +71,6 @@ feral-controld
 feral-setupd
 feral-sys-monitord
 feral-watchdog
+
+# Local static bundle for ff-player (feral-ff-player-static.service / serve-ff-player-static.sh)
+darkhttpd

--- a/archiso-ff1/packages.x86_64
+++ b/archiso-ff1/packages.x86_64
@@ -71,7 +71,7 @@ feral-controld
 feral-setupd
 feral-sys-monitord
 feral-watchdog
-ff-player
+feral-player
 
-# HTTP server to serve ff-player static
+# HTTP server to serve feral-player static
 darkhttpd

--- a/archiso-ff1/packages.x86_64
+++ b/archiso-ff1/packages.x86_64
@@ -71,6 +71,7 @@ feral-controld
 feral-setupd
 feral-sys-monitord
 feral-watchdog
+ff-player
 
-# Local static bundle for ff-player
+# HTTP server to serve ff-player static
 darkhttpd

--- a/archiso-ff1/packages.x86_64
+++ b/archiso-ff1/packages.x86_64
@@ -66,11 +66,11 @@ intel-gpu-tools
 lm_sensors
 earlyoom
 
-# Feralfile 
+# Feralfile
 feral-controld
 feral-setupd
 feral-sys-monitord
 feral-watchdog
 
-# Local static bundle for ff-player (feral-ff-player-static.service / serve-ff-player-static.sh)
+# Local static bundle for ff-player
 darkhttpd


### PR DESCRIPTION
## Summary

Build the ff-player static export as part of the FFOS image pipeline by calling the reusable workflow in `feral-file/ff-player` (`build-ff-player-static.yaml`), then bundling the artifact into the archiso tree under `/opt/feral/ff-player`.

## Changes

- Add `ff_player_ref` workflow input (alongside `ffos_user_ref`).
- Job `build-ff-player-static` uses cross-repo `uses: feral-file/ff-player/.github/workflows/build-ff-player-static.yaml@…` with `REPO_ACCESS_TOKEN` for checkout.
- Download artifact `ff-player-static` in `build-image` and copy into `airootfs/opt/feral/ff-player`.
- Applied to `build-image-to-cf.yml`, `build-image-from-tags.yml`, and `pure-build-image-to-cf.yml`.

## Tracking

Related to https://github.com/feral-file/feral-file/issues/3397


Made with [Cursor](https://cursor.com)