### PR TITLE
docs: align README with FFOS verification workflows

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,25 @@
+name: Verify Repository
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - staging
+      - release
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify README and workflow configuration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Run repo verification
+        run: ./scripts/verify.sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: verify
+
+verify:
+	./scripts/verify.sh

--- a/README.md
+++ b/README.md
@@ -1,32 +1,166 @@
 # FFOS - Arch Linux ISO Build Repository
 
-FFOS is the centralized build repository for FF1 operating system images. It coordinates Arch ISO generation, FFOS component packaging, local player packaging, pacman repository updates, and image upload/signing.
+## Architecture Overview
 
-The build uses source and user data from companion repositories:
+FFOS is the centralized build repository responsible for creating FFOS images. It orchestrates the entire build process by coordinating with the ffos-user repository for components and user data.
 
-```text
-ffos-user/components/  -> component pacman packages -> R2 {branch}/os/x86_64/
-ffos-user/users/       -> ISO home directory content
-ff-player              -> optional feral-player static package
-ffos/archiso-ff1       -> Arch ISO profile
+```
+┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
+│   ffos-user     │    │      ffos       │    │   R2 Storage    │
+│   Repository    │    │   Repository    │    │                 │
+│                 │    │                 │    │                 │
+│ ┌─────────────┐ │    │ ┌─────────────┐ │    │ ┌─────────────┐ │
+│ │ components/ │ │    │ │   GitHub    │ │    │ │ {branch}/   │ │
+│ │ users/      │ │    │ │  Actions    │ │    │ │ os/x86_64/  │ │
+│ └─────────────┘ │    │ └─────────────┘ │    │ │ *.iso       │ │
+│                 │    │                 │    │ └─────────────┘ │
+└─────────────────┘    └─────────────────┘    └─────────────────┘
+         │                       │                       ▲
+         │                       │                       │
+         │                       │                       │
+         ▼                       ▼                       │
+   Component Code         Build Process           Upload Results
+   User Data             ISO Generation
 ```
 
 ## Repository Structure
 
-```text
+```
 ffos/
-|-- .github/actions/setup-pacman/       # Shared pacman snapshot setup action
-|-- .github/workflows/                  # GitHub Actions workflow definitions
-|-- archiso-ff1/                        # Archiso profile and package lists
-|-- docs/                               # Supporting system documentation
-|-- scripts/verify.sh                   # Repo-wide non-mutating verification
-|-- Makefile                            # Local command entry points
-`-- README.md
+├── .github/workflows/           # GitHub Actions workflows
+│   ├── build-components.yaml    # Individual component build
+│   ├── pacman-repo.yaml        # Pacman repository management
+│   ├── build-image-to-cf.yml   # Complete build pipeline
+│   └── pure-build-image-to-cf.yml # Pure ISO build
+├── archiso-ff1/           # Archiso configuration
+│   ├── airootfs/               # Root filesystem template
+│   ├── efiboot/                # EFI boot configuration
+│   ├── packages.x86_64         # Package list
+│   └── profiledef.sh           # Profile definition
+└── README.md                   # This file
+```
+
+## Workflow Architecture
+
+### 1. Component Build Layer (`build-components.yaml`)
+
+**Purpose**: Build individual components from ffos-user repository
+
+**Inputs**:
+- `component`: Component name (feral-controld, feral-setupd, etc.)
+- `version`: Package version
+- `ffos_user_ref`: ffos-user repository reference
+- `environment`: Build environment (Development/Production)
+
+**Process**:
+1. Checkout ffos-user repository using specified reference
+2. Determine build type (Go/Rust) based on component
+3. Create pacman package with PKGBUILD
+4. Upload package to R2 storage
+
+**Output**: Pacman package uploaded to `{branch}/os/x86_64/`
+
+### 2. Repository Management Layer (`pacman-repo.yaml`)
+
+**Purpose**: Manage pacman repository database
+
+**Process**:
+1. Download all packages from R2
+2. Generate repository database
+3. Clean old packages
+4. Upload updated database
+
+**Output**: Updated `feralfile.db.tar.gz` and `feralfile.files.tar.gz`
+
+### 3. ISO Build Layer (`build-image-to-cf.yml`)
+
+**Purpose**: Complete ISO build pipeline
+
+**Workflow**:
+```
+┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
+│  Build All      │    │  Update Pacman  │    │  Build ISO      │
+│  Components     │───▶│   Repository    │───▶│   Image         │
+└─────────────────┘    └─────────────────┘    └─────────────────┘
+         │                       │                       │
+         ▼                       ▼                       ▼
+   Upload Packages         Generate DB           Upload ISO
+   to R2 Storage          Clean Old Pkgs        to R2 Storage
+```
+
+**Steps**:
+1. **Component Build Phase**: Build all components in parallel
+2. **Repository Update Phase**: Update pacman repository
+3. **ISO Generation Phase**: 
+   - Copy archiso profile
+   - Merge user data from ffos-user
+   - Configure pacman repositories
+   - Build ISO image
+   - Upload to R2
+
+### 4. Pure Build Layer (`pure-build-image-to-cf.yml`)
+
+**Purpose**: Fast ISO build without component building
+
+**Use Case**: When components already exist in R2 storage
+
+**Process**:
+1. Skip component building
+2. Directly build ISO with existing components
+3. Upload ISO to R2
+
+## Data Flow Architecture
+
+### Component Data Flow
+```
+ffos-user/components/ → ffos build process → R2/{branch}/os/x86_64/
+```
+
+### User Data Flow
+```
+ffos-user/users/ → ISO airootfs/home/ → Final ISO
+```
+
+### Configuration Flow
+```
+ffos-user/users/feralfile/.config/ → ISO /home/feralfile/.config/
+ffos-user/users/soaktest/ → ISO /home/soaktest/ (conditional)
+```
+
+## Build Configuration
+
+### Environment Variables
+- `CLOUDFLARE_ACCOUNT_ID`: Cloudflare account identifier
+- `CLOUDFLARE_ACCESS_KEY_ID`: R2 access key
+- `CLOUDFLARE_SECRET_ACCESS_KEY`: R2 secret key
+- `REPO_ACCESS_TOKEN`: GitHub token for ffos-user access
+
+### Build Parameters
+- `version`: ISO version number
+- `ffos_user_ref`: ffos-user repository reference
+- `soak-test`: Include soak test components
+- `environment`: Development/Production environment
+- `is_development`: Include development tools
+- `install_to_emmc`: Build installation image
+
+## R2 Storage Structure
+
+```
+{branch}/
+├── os/x86_64/
+│   ├── feral-controld-{version}-x86_64.pkg.tar.zst
+│   ├── feral-setupd-{version}-x86_64.pkg.tar.zst
+│   ├── feral-sys-monitord-{version}-x86_64.pkg.tar.zst
+│   ├── feral-watchdog-{version}-x86_64.pkg.tar.zst
+│   ├── feralfile.db.tar.gz
+│   └── feralfile.files.tar.gz
+├── FF1-{develop|release|demo|other}-{version}.iso
+└── release_notes_{version}.md
 ```
 
 ## Local Verification
 
-Run the same non-mutating verification path used by CI:
+Run the same non-mutating repository verification path used by CI:
 
 ```sh
 make verify
@@ -61,7 +195,7 @@ This workflow is intended for fast repository configuration validation. Release/
 
 | Workflow | Trigger | Purpose |
 | --- | --- | --- |
-| `build-image-to-cf.yml` | `workflow_dispatch` | Full FFOS image pipeline: build component packages, build the local player package, update the pacman repo DB, build/sign/upload the ISO, and update version metadata. |
+| `build-image-to-cf.yml` | `workflow_dispatch` | Full FFOS image pipeline: build component packages, update the pacman repo DB, build/sign/upload the ISO, and update version metadata. |
 | `pure-build-image-to-cf.yml` | `workflow_dispatch` | Build/sign/upload an FFOS image using packages that already exist in the remote pacman repo. |
 | `build-image-from-tags.yml` | `workflow_dispatch` | Build an image from explicit `ffos`, `ffos-user`, and optional `ff-player` refs. Component/player packages are built locally for the image path instead of uploaded first. |
 
@@ -82,78 +216,3 @@ This workflow is intended for fast repository configuration validation. Release/
 | `pacman-repo.yaml` | `workflow_call` | Download packages from R2, rebuild/sign the pacman DB, and upload the DB files. |
 | `permission-check.yaml` | `workflow_call` | Restrict privileged staging/release workflow runs to repository admins. |
 | `resolve-container.yaml` | `workflow_call` | Resolve the Arch Linux container image for a requested pacman snapshot. |
-
-## Common Manual Inputs
-
-The manually dispatched workflows share these input patterns where applicable:
-
-| Input | Used by | Meaning |
-| --- | --- | --- |
-| `version` | image, component, and player builds | Image/package version to produce. |
-| `environment` | image, package, and repo workflows | GitHub environment, usually `Development` or `Production`. |
-| `pacman_snapshot` | image, package, and repo workflows | Arch repository snapshot. Current choices are `2025/11/25`, `2025/05/31`, and `latest`. |
-| `ffos_user_ref` | image and component workflows | `feral-file/ffos-user` branch, tag, or commit to checkout. |
-| `ff_player_ref` | image and player workflows | `feral-file/ff-player` branch, tag, or commit to checkout. In `build-image-from-tags.yml`, this is optional and enables local player packaging only when supported by the selected FFOS ref. |
-| `ffos_ref` | `build-image-from-tags.yml` | `feral-file/ffos` branch, tag, or commit used for a tag-based image build. |
-| `component` | `manual-build-components.yaml` | Component package to build, such as `feral-controld`, `feral-setupd`, `feral-sys-monitord`, `feral-watchdog`, or `launcher-ui`. |
-| `soak-test` | image workflows | Include soak test user data and packages. |
-| `dev_iso` | image workflows | Add development tools and source metadata to the ISO. |
-| `enable_local_hub` | image workflows | Set local hub support in generated runtime config. |
-| `update_min_version` | image upload workflows | Update `min_runtime_version` in `version-info.json`. |
-| `update_required_version` | image upload workflows | Update `min_upgradeable_version` in `version-info.json`. |
-| `update_recovery_version` | image upload workflows | Update `recovery_version` in `version-info.json`. |
-
-## Build Outputs
-
-Uploaded artifacts use the current GitHub ref name as the R2 channel:
-
-```text
-{branch}/
-|-- os/x86_64/
-|   |-- feral-controld-{version}-x86_64.pkg.tar.zst
-|   |-- feral-setupd-{version}-x86_64.pkg.tar.zst
-|   |-- feral-sys-monitord-{version}-x86_64.pkg.tar.zst
-|   |-- feral-watchdog-{version}-x86_64.pkg.tar.zst
-|   |-- feral-player-{version}-x86_64.pkg.tar.zst
-|   |-- feralfile.db.tar.gz
-|   `-- feralfile.files.tar.gz
-|-- FF1-{channel}-{version}.iso
-|-- FF1-{channel}-{version}.iso.sig
-`-- version-info.json
-```
-
-## Required Secrets and Variables
-
-Build and upload workflows require repository secrets and variables. `make verify` and `verify.yml` do not.
-
-Common required secrets:
-
-- `CLOUDFLARE_ACCOUNT_ID`
-- `CLOUDFLARE_ACCESS_KEY_ID`
-- `CLOUDFLARE_SECRET_ACCESS_KEY`
-- `REPO_ACCESS_TOKEN`
-- `AWS_KMS_FF1_RELEASE_SIGNER_ROLE_ARN`
-- `AWS_KMS_FF1_RELEASE_SIGNING_KEY_ID`
-
-Additional image/player configuration may use:
-
-- `SENTRY_AUTH_TOKEN`
-- `SENTRY_ORG`
-- `SENTRY_DSN_PLAYER`
-- `SENTRY_DSN_CONTROLD`
-- `SENTRY_DSN_WATCHDOG`
-- `SENTRY_DSN_SYS_MONITORD`
-- `RELAYER_API_KEY`
-- `HEARTBEAT_ENDPOINT`
-- `VMAGENT_REMOTE_URL`
-- `VMAGENT_REMOTE_BEARER_TOKEN`
-- `OPENPANEL_CLIENT_ID`
-- `OPENPANEL_CLIENT_ID_TEST`
-- `OPENPANEL_CLIENT_SECRET`
-- `OPENPANEL_CLIENT_SECRET_TEST`
-
-Common variables:
-
-- `CLOUDFLARE_R2_BUCKET_NAME`
-- `PUB_DOC_URL`
-- `RELAYER_ENDPOINT`

--- a/README.md
+++ b/README.md
@@ -1,159 +1,159 @@
 # FFOS - Arch Linux ISO Build Repository
 
-## Architecture Overview
+FFOS is the centralized build repository for FF1 operating system images. It coordinates Arch ISO generation, FFOS component packaging, local player packaging, pacman repository updates, and image upload/signing.
 
-FFOS is the centralized build repository responsible for creating FFOS images. It orchestrates the entire build process by coordinating with the ffos-user repository for components and user data.
+The build uses source and user data from companion repositories:
 
-```
-┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
-│   ffos-user     │    │      ffos       │    │   R2 Storage    │
-│   Repository    │    │   Repository    │    │                 │
-│                 │    │                 │    │                 │
-│ ┌─────────────┐ │    │ ┌─────────────┐ │    │ ┌─────────────┐ │
-│ │ components/ │ │    │ │   GitHub    │ │    │ │ {branch}/   │ │
-│ │ users/      │ │    │ │  Actions    │ │    │ │ os/x86_64/  │ │
-│ └─────────────┘ │    │ └─────────────┘ │    │ │ *.iso       │ │
-│                 │    │                 │    │ └─────────────┘ │
-└─────────────────┘    └─────────────────┘    └─────────────────┘
-         │                       │                       ▲
-         │                       │                       │
-         │                       │                       │
-         ▼                       ▼                       │
-   Component Code         Build Process           Upload Results
-   User Data             ISO Generation
+```text
+ffos-user/components/  -> component pacman packages -> R2 {branch}/os/x86_64/
+ffos-user/users/       -> ISO home directory content
+ff-player              -> optional feral-player static package
+ffos/archiso-ff1       -> Arch ISO profile
 ```
 
 ## Repository Structure
 
-```
+```text
 ffos/
-├── .github/workflows/           # GitHub Actions workflows
-│   ├── build-components.yaml    # Individual component build
-│   ├── pacman-repo.yaml        # Pacman repository management
-│   ├── build-image-to-cf.yml   # Complete build pipeline
-│   └── pure-build-image-to-cf.yml # Pure ISO build
-├── archiso-ff1/           # Archiso configuration
-│   ├── airootfs/               # Root filesystem template
-│   ├── efiboot/                # EFI boot configuration
-│   ├── packages.x86_64         # Package list
-│   └── profiledef.sh           # Profile definition
-└── README.md                   # This file
+|-- .github/actions/setup-pacman/       # Shared pacman snapshot setup action
+|-- .github/workflows/                  # GitHub Actions workflow definitions
+|-- archiso-ff1/                        # Archiso profile and package lists
+|-- docs/                               # Supporting system documentation
+|-- scripts/verify.sh                   # Repo-wide non-mutating verification
+|-- Makefile                            # Local command entry points
+`-- README.md
 ```
 
-## Workflow Architecture
+## Local Verification
 
-### 1. Component Build Layer (`build-components.yaml`)
+Run the same non-mutating verification path used by CI:
 
-**Purpose**: Build individual components from ffos-user repository
-
-**Inputs**:
-- `component`: Component name (feral-controld, feral-setupd, etc.)
-- `version`: Package version
-- `ffos_user_ref`: ffos-user repository reference
-- `environment`: Build environment (Development/Production)
-
-**Process**:
-1. Checkout ffos-user repository using specified reference
-2. Determine build type (Go/Rust) based on component
-3. Create pacman package with PKGBUILD
-4. Upload package to R2 storage
-
-**Output**: Pacman package uploaded to `{branch}/os/x86_64/`
-
-### 2. Repository Management Layer (`pacman-repo.yaml`)
-
-**Purpose**: Manage pacman repository database
-
-**Process**:
-1. Download all packages from R2
-2. Generate repository database
-3. Clean old packages
-4. Upload updated database
-
-**Output**: Updated `feralfile.db.tar.gz` and `feralfile.files.tar.gz`
-
-### 3. ISO Build Layer (`build-image-to-cf.yml`)
-
-**Purpose**: Complete ISO build pipeline
-
-**Workflow**:
-```
-┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
-│  Build All      │    │  Update Pacman  │    │  Build ISO      │
-│  Components     │───▶│   Repository    │───▶│   Image         │
-└─────────────────┘    └─────────────────┘    └─────────────────┘
-         │                       │                       │
-         ▼                       ▼                       ▼
-   Upload Packages         Generate DB           Upload ISO
-   to R2 Storage          Clean Old Pkgs        to R2 Storage
+```sh
+make verify
 ```
 
-**Steps**:
-1. **Component Build Phase**: Build all components in parallel
-2. **Repository Update Phase**: Update pacman repository
-3. **ISO Generation Phase**: 
-   - Copy archiso profile
-   - Merge user data from ffos-user
-   - Configure pacman repositories
-   - Build ISO image
-   - Upload to R2
+`make verify` calls `scripts/verify.sh`, which checks shell syntax, runs ShellCheck, validates GitHub workflow YAML shape, confirms the CI verification workflow calls the same script, and confirms this README lists every workflow file.
 
-### 4. Pure Build Layer (`pure-build-image-to-cf.yml`)
+Required local tools:
 
-**Purpose**: Fast ISO build without component building
+- `bash`
+- `ruby`
+- `shellcheck`
+- `make`
 
-**Use Case**: When components already exist in R2 storage
+The verification path does not build packages, build an ISO, sign artifacts, upload to R2, or require repository secrets.
 
-**Process**:
-1. Skip component building
-2. Directly build ISO with existing components
-3. Upload ISO to R2
+## GitHub Actions Verification
 
-## Data Flow Architecture
+`.github/workflows/verify.yml` runs the same `scripts/verify.sh` path on pull requests, pushes to long-lived branches, and manual dispatch.
 
-### Component Data Flow
-```
-ffos-user/components/ → ffos build process → R2/{branch}/os/x86_64/
-```
+This workflow is intended for fast repository configuration validation. Release/package/image workflows remain manual or reusable because they require privileged containers, external repositories, repository secrets, Cloudflare R2 access, and AWS KMS signing.
 
-### User Data Flow
-```
-ffos-user/users/ → ISO airootfs/home/ → Final ISO
-```
+## Workflow Inventory
 
-### Configuration Flow
-```
-ffos-user/users/feralfile/.config/ → ISO /home/feralfile/.config/
-ffos-user/users/soaktest/ → ISO /home/soaktest/ (conditional)
-```
+### Validation
 
-## Build Configuration
+| Workflow | Trigger | Purpose |
+| --- | --- | --- |
+| `verify.yml` | `pull_request`, selected `push` branches, `workflow_dispatch` | Non-mutating repository verification shared with `make verify`. |
 
-### Environment Variables
-- `CLOUDFLARE_ACCOUNT_ID`: Cloudflare account identifier
-- `CLOUDFLARE_ACCESS_KEY_ID`: R2 access key
-- `CLOUDFLARE_SECRET_ACCESS_KEY`: R2 secret key
-- `REPO_ACCESS_TOKEN`: GitHub token for ffos-user access
+### Full image builds
 
-### Build Parameters
-- `version`: ISO version number
-- `ffos_user_ref`: ffos-user repository reference
-- `soak-test`: Include soak test components
-- `environment`: Development/Production environment
-- `is_development`: Include development tools
-- `install_to_emmc`: Build installation image
+| Workflow | Trigger | Purpose |
+| --- | --- | --- |
+| `build-image-to-cf.yml` | `workflow_dispatch` | Full FFOS image pipeline: build component packages, build the local player package, update the pacman repo DB, build/sign/upload the ISO, and update version metadata. |
+| `pure-build-image-to-cf.yml` | `workflow_dispatch` | Build/sign/upload an FFOS image using packages that already exist in the remote pacman repo. |
+| `build-image-from-tags.yml` | `workflow_dispatch` | Build an image from explicit `ffos`, `ffos-user`, and optional `ff-player` refs. Component/player packages are built locally for the image path instead of uploaded first. |
 
-## R2 Storage Structure
+### Manual package and repository operations
 
-```
+| Workflow | Trigger | Purpose |
+| --- | --- | --- |
+| `manual-build-components.yaml` | `workflow_dispatch` | Build and upload one selected `ffos-user` component package. |
+| `manual-build-feral-player.yaml` | `workflow_dispatch` | Build and upload the `feral-player` pacman package from an `ff-player` ref. |
+| `manual-push-pacman-repo.yaml` | `workflow_dispatch` | Rebuild and upload the remote pacman repository database from packages already in R2. |
+
+### Reusable workflows
+
+| Workflow | Trigger | Purpose |
+| --- | --- | --- |
+| `build-components.yaml` | `workflow_call` | Package one `ffos-user` component and upload the package/signature to R2. |
+| `build-feral-player.yaml` | `workflow_call` | Build the `ff-player` static export, package it as `feral-player`, and upload package artifacts to R2. |
+| `pacman-repo.yaml` | `workflow_call` | Download packages from R2, rebuild/sign the pacman DB, and upload the DB files. |
+| `permission-check.yaml` | `workflow_call` | Restrict privileged staging/release workflow runs to repository admins. |
+| `resolve-container.yaml` | `workflow_call` | Resolve the Arch Linux container image for a requested pacman snapshot. |
+
+## Common Manual Inputs
+
+The manually dispatched workflows share these input patterns where applicable:
+
+| Input | Used by | Meaning |
+| --- | --- | --- |
+| `version` | image, component, and player builds | Image/package version to produce. |
+| `environment` | image, package, and repo workflows | GitHub environment, usually `Development` or `Production`. |
+| `pacman_snapshot` | image, package, and repo workflows | Arch repository snapshot. Current choices are `2025/11/25`, `2025/05/31`, and `latest`. |
+| `ffos_user_ref` | image and component workflows | `feral-file/ffos-user` branch, tag, or commit to checkout. |
+| `ff_player_ref` | image and player workflows | `feral-file/ff-player` branch, tag, or commit to checkout. In `build-image-from-tags.yml`, this is optional and enables local player packaging only when supported by the selected FFOS ref. |
+| `ffos_ref` | `build-image-from-tags.yml` | `feral-file/ffos` branch, tag, or commit used for a tag-based image build. |
+| `component` | `manual-build-components.yaml` | Component package to build, such as `feral-controld`, `feral-setupd`, `feral-sys-monitord`, `feral-watchdog`, or `launcher-ui`. |
+| `soak-test` | image workflows | Include soak test user data and packages. |
+| `dev_iso` | image workflows | Add development tools and source metadata to the ISO. |
+| `enable_local_hub` | image workflows | Set local hub support in generated runtime config. |
+| `update_min_version` | image upload workflows | Update `min_runtime_version` in `version-info.json`. |
+| `update_required_version` | image upload workflows | Update `min_upgradeable_version` in `version-info.json`. |
+| `update_recovery_version` | image upload workflows | Update `recovery_version` in `version-info.json`. |
+
+## Build Outputs
+
+Uploaded artifacts use the current GitHub ref name as the R2 channel:
+
+```text
 {branch}/
-├── os/x86_64/
-│   ├── feral-controld-{version}-x86_64.pkg.tar.zst
-│   ├── feral-setupd-{version}-x86_64.pkg.tar.zst
-│   ├── feral-sys-monitord-{version}-x86_64.pkg.tar.zst
-│   ├── feral-watchdog-{version}-x86_64.pkg.tar.zst
-│   ├── feralfile.db.tar.gz
-│   └── feralfile.files.tar.gz
-├── FF1-{develop|release|demo|other}-{version}.iso
-└── release_notes_{version}.md
+|-- os/x86_64/
+|   |-- feral-controld-{version}-x86_64.pkg.tar.zst
+|   |-- feral-setupd-{version}-x86_64.pkg.tar.zst
+|   |-- feral-sys-monitord-{version}-x86_64.pkg.tar.zst
+|   |-- feral-watchdog-{version}-x86_64.pkg.tar.zst
+|   |-- feral-player-{version}-x86_64.pkg.tar.zst
+|   |-- feralfile.db.tar.gz
+|   `-- feralfile.files.tar.gz
+|-- FF1-{channel}-{version}.iso
+|-- FF1-{channel}-{version}.iso.sig
+`-- version-info.json
 ```
+
+## Required Secrets and Variables
+
+Build and upload workflows require repository secrets and variables. `make verify` and `verify.yml` do not.
+
+Common required secrets:
+
+- `CLOUDFLARE_ACCOUNT_ID`
+- `CLOUDFLARE_ACCESS_KEY_ID`
+- `CLOUDFLARE_SECRET_ACCESS_KEY`
+- `REPO_ACCESS_TOKEN`
+- `AWS_KMS_FF1_RELEASE_SIGNER_ROLE_ARN`
+- `AWS_KMS_FF1_RELEASE_SIGNING_KEY_ID`
+
+Additional image/player configuration may use:
+
+- `SENTRY_AUTH_TOKEN`
+- `SENTRY_ORG`
+- `SENTRY_DSN_PLAYER`
+- `SENTRY_DSN_CONTROLD`
+- `SENTRY_DSN_WATCHDOG`
+- `SENTRY_DSN_SYS_MONITORD`
+- `RELAYER_API_KEY`
+- `HEARTBEAT_ENDPOINT`
+- `VMAGENT_REMOTE_URL`
+- `VMAGENT_REMOTE_BEARER_TOKEN`
+- `OPENPANEL_CLIENT_ID`
+- `OPENPANEL_CLIENT_ID_TEST`
+- `OPENPANEL_CLIENT_SECRET`
+- `OPENPANEL_CLIENT_SECRET_TEST`
+
+Common variables:
+
+- `CLOUDFLARE_R2_BUCKET_NAME`
+- `PUB_DOC_URL`
+- `RELAYER_ENDPOINT`

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+log() {
+  printf '==> %s\n' "$1"
+}
+
+require_tool() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'Missing required tool: %s\n' "$1" >&2
+    exit 127
+  fi
+}
+
+require_tool bash
+require_tool ruby
+require_tool shellcheck
+
+log "Checking shell syntax"
+bash -n scripts/verify.sh archiso-ff1/profiledef.sh
+
+log "Running shellcheck"
+shellcheck scripts/verify.sh archiso-ff1/profiledef.sh
+
+log "Validating GitHub workflow YAML"
+ruby <<'RUBY'
+require "yaml"
+
+paths = Dir[".github/workflows/*.{yml,yaml}"].sort
+abort "No GitHub workflows found" if paths.empty?
+
+paths.each do |path|
+  data = YAML.load(File.read(path))
+  unless data.is_a?(Hash)
+    abort "#{path}: expected top-level YAML mapping"
+  end
+
+  missing = []
+  missing << "name" unless data.key?("name")
+  missing << "on" unless data.key?("on") || data.key?(true)
+  missing << "jobs" unless data.key?("jobs")
+  abort "#{path}: missing #{missing.join(", ")}" unless missing.empty?
+end
+
+puts "Validated #{paths.length} workflow files."
+RUBY
+
+log "Checking verification workflow contract"
+grep -q "scripts/verify.sh" .github/workflows/verify.yml
+grep -q "^verify:" Makefile
+grep -q "make verify" README.md
+
+log "Checking README workflow inventory"
+while IFS= read -r workflow; do
+  grep -q "$(basename "$workflow")" README.md || {
+    printf 'README.md does not mention %s\n' "$workflow" >&2
+    exit 1
+  }
+done < <(find .github/workflows -maxdepth 1 -type f | sort)
+
+log "Verification complete"


### PR DESCRIPTION
## Problem
README.md documented only part of the current GitHub Actions surface and included stale workflow/input descriptions. The repo also lacked a single root local verification command that matched CI.

## Why it matters
Maintainers need one accurate place to understand the manual/reusable FFOS build workflows, and contributors need a deterministic non-mutating check before opening PRs.

## Acceptance checks
- README lists the current workflow inventory, triggers, purpose, and shared manual inputs, including component, player, image, tag, pacman repo, permission, container, and verification workflows.
- `make verify` is the repo-wide local verification entry point and calls `scripts/verify.sh`.
- GitHub Actions verification uses the same non-mutating `scripts/verify.sh` path.

## Validation run
- `make verify`

Fixes feral-file/ffos-user#162