### PR TITLE
feat(ota): fail-fast downloads and align error messages with setupd

### DIFF
--- a/archiso-ff1/airootfs/root/scripts/feral-recovery-update.sh
+++ b/archiso-ff1/airootfs/root/scripts/feral-recovery-update.sh
@@ -185,13 +185,24 @@ mount -o compress=zstd,noatime,subvol=@snapshots/@recovery_candidate_new "$ROOT_
 log_info "Downloading recovery ISO..."
 mkdir -p "$TMP_DIR"
 
-curl --silent --show-error -fL "$ENDPOINT$RECOVERY_URL" -o "$ISO_FILE" || {
-  log_error "Failed to download recovery ISO from $ENDPOINT$RECOVERY_URL"
+# Download recovery ISO with stall detection but no overall timeout.
+# Recovery images can be large (2-4GB), so allow time for slow connections.
+# Stall detection ensures we abort if truly stuck (< 1KB/s for 60s).
+curl --silent --show-error --fail --location \
+  --connect-timeout 15 \
+  --speed-time 60 \
+  --speed-limit 1024 \
+  "$ENDPOINT$RECOVERY_URL" -o "$ISO_FILE" || {
+  log_error "Failed to download recovery ISO."
   exit 1
 }
 
 log_info "Downloading signature file..."
-curl --silent --show-error -fL "$ENDPOINT$RECOVERY_URL.sig" -o "$ISO_FILE.sig" || {
+# Signature file is tiny, can use shorter timeout
+curl --silent --show-error --fail --location \
+  --connect-timeout 15 \
+  --max-time 60 \
+  "$ENDPOINT$RECOVERY_URL.sig" -o "$ISO_FILE.sig" || {
   log_error "Failed to download signature file."
   exit 1
 }

--- a/archiso-ff1/airootfs/root/scripts/feral-system-update.sh
+++ b/archiso-ff1/airootfs/root/scripts/feral-system-update.sh
@@ -17,41 +17,35 @@ log_error() {
   echo "$(date '+%Y-%m-%dT%H:%M:%S%z') [ERROR] id=$UNIQUE_ID message=\"$message\""
 }
 
-download_with_retry() {
+download_file() {
   local url="$1"
   local output="$2"
   local label="$3"
-  local max_attempts=5
-  local retry_delay=10
-  local attempt=1
 
-  while [[ $attempt -le $max_attempts ]]; do
-    log_info "Downloading $label, attempt $attempt/$max_attempts"
+  log_info "Downloading $label"
 
-    if curl \
-      --silent \
-      --show-error \
-      --fail \
-      --location \
-      --connect-timeout 15 \
-      --speed-time 60 \
-      --speed-limit 1024 \
-      "$url" \
-      -o "$output"; then
-      return 0
-    fi
+  # Download with stall detection but no overall timeout.
+  # For large OTA images (2-4GB), download time varies widely based on network:
+  #   - Fast (100 Mbps): ~4 minutes
+  #   - Moderate (10 Mbps): ~40 minutes
+  #   - Slow (1 Mbps): ~400 minutes
+  # Stall detection (--speed-time 60 + --speed-limit 1024) ensures we abort
+  # if truly stuck, but allow slow-but-progressing downloads to complete.
+  if ! curl \
+    --silent \
+    --show-error \
+    --fail \
+    --location \
+    --connect-timeout 15 \
+    --speed-time 60 \
+    --speed-limit 1024 \
+    "$url" \
+    -o "$output"; then
+    log_error "Failed to download $label."
+    return 1
+  fi
 
-    log_info "Download attempt $attempt/$max_attempts failed for $label."
-    attempt=$((attempt + 1))
-
-    if [[ $attempt -le $max_attempts ]]; then
-      log_info "Retrying $label download in $retry_delay seconds..."
-      sleep "$retry_delay"
-    fi
-  done
-
-  log_error "Failed to download $label after $max_attempts attempts."
-  return 1
+  return 0
 }
 
 trap 'code=$?; log_error "EXCEPTION ERR: LINE=$LINENO CMD=\"$BASH_COMMAND\""; exit $code' ERR
@@ -185,17 +179,16 @@ PROGRESS_PID=""
 ) &
 PROGRESS_PID=$!
 
-# Actual download. Retry protects setup from transient Wi-Fi drops during
-# first-run OTA.
-download_with_retry "$ENDPOINT$IMAGE_URL" "$ISO_FILE" "OTA image"
+# Download the ISO. Setupd will retry transient failures at the Rust level.
+download_file "$ENDPOINT$IMAGE_URL" "$ISO_FILE" "OTA image"
 
 kill "$PROGRESS_PID" 2>/dev/null || true
 
 # Download signature file
 log_progress "80" "Verifying download integrity..."
 
-download_with_retry "$ENDPOINT$IMAGE_URL.sig" "$ISO_FILE.sig" "OTA signature" || {
-  log_error "Error: Failed to download file $ISO_FILE.sig."
+download_file "$ENDPOINT$IMAGE_URL.sig" "$ISO_FILE.sig" "signature file" || {
+  log_error "Failed to download signature file."
   exit 1
 }
 


### PR DESCRIPTION
## Summary

Removes script-side OTA download retries so `feral-setupd` owns transient retry policy. Scripts fail fast with stall detection suitable for large images and emit stable error strings for setupd classification.

**Companion PR:** feral-file/ffos-user#206

## Changes

### `feral-system-update.sh`
- Replace `download_with_retry()` (5×10s loop) with fail-fast `download_file()`
- Use stall detection (`--speed-time 60`, `--speed-limit 1024`) without overall `--max-time` for large OTA images
- Standardize download error messages for setupd classifier (e.g. `Failed to download signature file.`)

### `feral-recovery-update.sh`
- Add consistent curl timeout/stall parameters for recovery ISO download
- Keep short `--max-time 60` for tiny signature file
- Align error messages with system update script and setupd classifier

## Why it matters

Retry logic was duplicated between bash scripts and Rust, causing inconsistent behavior and harder classification. Centralizing retries in setupd gives a single backoff policy and clearer transient vs permanent handling for mobile recovery UX.

## Test plan

- [ ] System OTA: transient network drop during download fails fast; setupd retries with backoff
- [ ] System OTA: large image download completes on slow but progressing connection (no overall timeout)
- [ ] System OTA: stalled download (< 1 KB/s for 60s) aborts and is classified transient by setupd
- [ ] Recovery OTA: same stall/timeout behavior for recovery ISO and signature
- [ ] Error messages from scripts match `classify_updater_message()` in setupd