### PR TITLE
feat: split image build configuration

### DIFF
--- a/.github/workflows/build-feral-player.yaml
+++ b/.github/workflows/build-feral-player.yaml
@@ -22,6 +22,11 @@ on:
         required: true
         type: string
         default: 'Development'
+      configuration:
+        description: 'Runtime configuration set (Development or Production)'
+        required: false
+        type: string
+        default: 'Development'
       ff_player_ref:
         description: 'feral-player repository reference'
         required: true
@@ -100,7 +105,7 @@ jobs:
 
       - name: Validate required environment variables
         env:
-          NEXT_PUBLIC_ENVIRONMENT: ${{ inputs.environment }}
+          NEXT_PUBLIC_ENVIRONMENT: ${{ inputs.configuration }}
           NEXT_PUBLIC_PUB_DOC_URL: ${{ vars.PUB_DOC_URL }}
           NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.SENTRY_DSN_PLAYER }}
         run: |
@@ -116,7 +121,7 @@ jobs:
       - name: Build static export
         working-directory: feral-player
         env:
-          NEXT_PUBLIC_ENVIRONMENT: ${{ inputs.environment }}
+          NEXT_PUBLIC_ENVIRONMENT: ${{ inputs.configuration }}
           NEXT_PUBLIC_PUB_DOC_URL: ${{ vars.PUB_DOC_URL }}
           NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.SENTRY_DSN_PLAYER }}
           NEXT_PUBLIC_DISABLE_VERSION_CHECK: 'true'

--- a/.github/workflows/build-image-from-tags.yml
+++ b/.github/workflows/build-image-from-tags.yml
@@ -29,7 +29,15 @@ on:
           - false
         default: false
       environment:
-        description: "Environment to build"
+        description: "Where to build"
+        required: true
+        default: "Development"
+        type: choice
+        options:
+          - Development
+          - Production
+      configuration:
+        description: "Configuration set to build the image"
         required: true
         default: "Development"
         type: choice
@@ -181,7 +189,7 @@ jobs:
         if: ${{ needs.determine-local-player.outputs.enabled == 'true' }}
         working-directory: feral-player
         env:
-          NEXT_PUBLIC_ENVIRONMENT: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
+          NEXT_PUBLIC_ENVIRONMENT: ${{ inputs.configuration || github.event.inputs.configuration || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
           NEXT_PUBLIC_PUB_DOC_URL: ${{ vars.PUB_DOC_URL }}
           NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.SENTRY_DSN_PLAYER }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -392,12 +400,6 @@ jobs:
         run: |
           set -e
 
-          if [ "${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}" = "Production" ]; then
-            DOMAIN="ffos.feralfile.com"
-          else
-            DOMAIN="ffosdev.feralfile.com"
-          fi
-
           # Save the archiso profile's original pacman.conf before modifying
           cp /build/archiso-ff1/pacman.conf /build/archiso-ff1/pacman.conf.orig
 
@@ -415,7 +417,15 @@ jobs:
           # Runtime pacman config inside ISO should point to remote R2 repo only,
           # so systems can update to latest packages from that channel.
           # Use archiso profile's original pacman.conf as base (not the container's /etc/pacman.conf)
+          CONFIGURATION="${{ inputs.configuration || github.event.inputs.configuration || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}"
+
           cp /build/archiso-ff1/pacman.conf.orig /build/archiso-ff1/airootfs/etc/pacman.conf
+          if [ "$CONFIGURATION" = "Production" ]; then
+            DOMAIN="ffos.feralfile.com"
+          else
+            DOMAIN="ffosdev.feralfile.com"
+          fi
+
           cat >> /build/archiso-ff1/airootfs/etc/pacman.conf << EOF
           [feralfile]
           SigLevel = Required DatabaseOptional TrustedOnly
@@ -432,10 +442,19 @@ jobs:
 
       - name: Add Configs and Services
         run: |
-          if [ "${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}" = "Production" ]; then
+          CONFIGURATION="${{ inputs.configuration || github.event.inputs.configuration || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}"
+          RELAYER_ENDPOINT="wss://relayer-dev.bitmark-development.workers.dev"
+
+          if [ "$CONFIGURATION" = "Production" ]; then
             ENDPOINT="https://ffos.feralfile.com"
+            SENTRY_SAMPLE_RATE="0.1"
+            OPENPANEL_CLIENT_ID="${{ secrets.OPENPANEL_CLIENT_ID }}"
+            OPENPANEL_CLIENT_SECRET="${{ secrets.OPENPANEL_CLIENT_SECRET }}"
           else
             ENDPOINT="https://ffosdev.feralfile.com"
+            SENTRY_SAMPLE_RATE="1.0"
+            OPENPANEL_CLIENT_ID="${{ secrets.OPENPANEL_CLIENT_ID_TEST }}"
+            OPENPANEL_CLIENT_SECRET="${{ secrets.OPENPANEL_CLIENT_SECRET_TEST }}"
           fi
 
           mkdir -p /build/archiso-ff1/airootfs/home/feralfile/.config
@@ -443,23 +462,30 @@ jobs:
           cat > /build/archiso-ff1/airootfs/home/feralfile/.config/controld.json << EOF
           {
             "relayer": {
-                "endpoint": "${{ vars.RELAYER_ENDPOINT }}",
+                "endpoint": "${RELAYER_ENDPOINT}",
                 "apiKey": "${{ secrets.RELAYER_API_KEY }}"
             },
             "cdp": {
                 "endpoint": "http://127.0.0.1:9222"
             },
+            "mintPairing": {
+                "enabled": true,
+                "brokerBaseURL": "https://handoff.feralfile.com",
+                "idleTTLSeconds": 300,
+                "pollIntervalMillis": 500,
+                "approvalTimeoutSeconds": 300
+            },
             "sentry": {
                 "dsn": "${{ secrets.SENTRY_DSN_CONTROLD }}",
                 "debug": "false",
-                "sample_rate": "${{ (github.event.inputs.environment == 'Production' || github.ref == 'refs/heads/main') && '0.1' || '1.0' }}",
-                "environment": "${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}",
+                "sample_rate": "${SENTRY_SAMPLE_RATE}",
+                "environment": "${CONFIGURATION}",
                 "release": "${{ inputs.version || github.event.inputs.version }}",
                 "repository": "${{ github.repository }}"
             },
             "openpanel": {
-              "clientId": "${{ github.event.inputs.environment == 'Production' && secrets.OPENPANEL_CLIENT_ID || secrets.OPENPANEL_CLIENT_ID_TEST }}",
-              "clientSecret": "${{ github.event.inputs.environment == 'Production' && secrets.OPENPANEL_CLIENT_SECRET || secrets.OPENPANEL_CLIENT_SECRET_TEST }}"
+              "clientId": "${OPENPANEL_CLIENT_ID}",
+              "clientSecret": "${OPENPANEL_CLIENT_SECRET}"
             },
             "enableHub": ${{ inputs.enable_local_hub || github.event.inputs.enable_local_hub }}
           }
@@ -474,8 +500,8 @@ jobs:
             "sentry": {
                 "dsn": "${{ secrets.SENTRY_DSN_WATCHDOG }}",
                 "debug": "false",
-                "sample_rate": "${{ (github.event.inputs.environment == 'Production' || github.ref == 'refs/heads/main') && '0.1' || '1.0' }}",
-                "environment": "${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}",
+                "sample_rate": "${SENTRY_SAMPLE_RATE}",
+                "environment": "${CONFIGURATION}",
                 "release": "${{ inputs.version || github.event.inputs.version }}",
                 "repository": "${{ github.repository }}"
             }
@@ -488,8 +514,8 @@ jobs:
             "sentry": {
                 "dsn": "${{ secrets.SENTRY_DSN_SYS_MONITORD }}",
                 "debug": "false",
-                "sample_rate": "${{ (github.event.inputs.environment == 'Production' || github.ref == 'refs/heads/main') && '0.1' || '1.0' }}",
-                "environment": "${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}",
+                "sample_rate": "${SENTRY_SAMPLE_RATE}",
+                "environment": "${CONFIGURATION}",
                 "release": "${{ inputs.version || github.event.inputs.version }}",
                 "repository": "${{ github.repository }}"
             }

--- a/.github/workflows/build-image-to-cf.yml
+++ b/.github/workflows/build-image-to-cf.yml
@@ -16,7 +16,15 @@ on:
           - false
         default: false
       environment:
-        description: "Environment to build"
+        description: "Where to build"
+        required: true
+        default: "Development"
+        type: choice
+        options:
+          - Development
+          - Production
+      configuration:
+        description: "Configuration set to build the image"
         required: true
         default: "Development"
         type: choice
@@ -182,6 +190,7 @@ jobs:
       description: 'FF Player Static Web Application'
       maintainer: 'Feral File'
       environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
+      configuration: ${{ inputs.configuration || github.event.inputs.configuration || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
       ff_player_ref: ${{ inputs.ff_player_ref || github.event.inputs.ff_player_ref }}
       pacman_snapshot: ${{ inputs.pacman_snapshot || github.event.inputs.pacman_snapshot }}
       container_image: ${{ needs.resolve-container.outputs.image }}
@@ -324,7 +333,9 @@ jobs:
         run: |
           set -e
 
-          if [ "${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}" = "Production" ]; then
+          CONFIGURATION="${{ inputs.configuration || github.event.inputs.configuration || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}"
+
+          if [ "$CONFIGURATION" = "Production" ]; then
             DOMAIN="ffos.feralfile.com"
           else
             DOMAIN="ffosdev.feralfile.com"
@@ -348,10 +359,19 @@ jobs:
 
       - name: Add Configs and Services
         run: |
-          if [ "${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}" = "Production" ]; then
+          CONFIGURATION="${{ inputs.configuration || github.event.inputs.configuration || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}"
+          RELAYER_ENDPOINT="wss://relayer-dev.bitmark-development.workers.dev"
+
+          if [ "$CONFIGURATION" = "Production" ]; then
             ENDPOINT="https://ffos.feralfile.com"
+            SENTRY_SAMPLE_RATE="0.1"
+            OPENPANEL_CLIENT_ID="${{ secrets.OPENPANEL_CLIENT_ID }}"
+            OPENPANEL_CLIENT_SECRET="${{ secrets.OPENPANEL_CLIENT_SECRET }}"
           else
             ENDPOINT="https://ffosdev.feralfile.com"
+            SENTRY_SAMPLE_RATE="1.0"
+            OPENPANEL_CLIENT_ID="${{ secrets.OPENPANEL_CLIENT_ID_TEST }}"
+            OPENPANEL_CLIENT_SECRET="${{ secrets.OPENPANEL_CLIENT_SECRET_TEST }}"
           fi
 
           # Add controld config
@@ -359,23 +379,30 @@ jobs:
           cat > /build/archiso-ff1/airootfs/home/feralfile/.config/controld.json << EOF
           {
             "relayer": {
-                "endpoint": "${{ vars.RELAYER_ENDPOINT }}",
+                "endpoint": "${RELAYER_ENDPOINT}",
                 "apiKey": "${{ secrets.RELAYER_API_KEY }}"
             },
             "cdp": {
                 "endpoint": "http://127.0.0.1:9222"
             },
+            "mintPairing": {
+                "enabled": true,
+                "brokerBaseURL": "https://handoff.feralfile.com",
+                "idleTTLSeconds": 300,
+                "pollIntervalMillis": 500,
+                "approvalTimeoutSeconds": 300
+            },
             "sentry": {
                 "dsn": "${{ secrets.SENTRY_DSN_CONTROLD }}",
                 "debug": "false",
-                "sample_rate": "${{ (github.event.inputs.environment == 'Production' || github.ref == 'refs/heads/main') && '0.1' || '1.0' }}",
-                "environment": "${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}",
+                "sample_rate": "${SENTRY_SAMPLE_RATE}",
+                "environment": "${CONFIGURATION}",
                 "release": "${{ inputs.version || github.event.inputs.version }}",
                 "repository": "${{ github.repository }}"
             },
             "openpanel": {
-              "clientId": "${{ github.event.inputs.environment == 'Production' && secrets.OPENPANEL_CLIENT_ID || secrets.OPENPANEL_CLIENT_ID_TEST }}",
-              "clientSecret": "${{ github.event.inputs.environment == 'Production' && secrets.OPENPANEL_CLIENT_SECRET || secrets.OPENPANEL_CLIENT_SECRET_TEST }}"
+              "clientId": "${OPENPANEL_CLIENT_ID}",
+              "clientSecret": "${OPENPANEL_CLIENT_SECRET}"
             },
             "enableHub": ${{ inputs.enable_local_hub || github.event.inputs.enable_local_hub }}
           }
@@ -391,8 +418,8 @@ jobs:
             "sentry": {
                 "dsn": "${{ secrets.SENTRY_DSN_WATCHDOG }}",
                 "debug": "false",
-                "sample_rate": "${{ (github.event.inputs.environment == 'Production' || github.ref == 'refs/heads/main') && '0.1' || '1.0' }}",
-                "environment": "${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}",
+                "sample_rate": "${SENTRY_SAMPLE_RATE}",
+                "environment": "${CONFIGURATION}",
                 "release": "${{ inputs.version || github.event.inputs.version }}",
                 "repository": "${{ github.repository }}"
             }
@@ -406,8 +433,8 @@ jobs:
             "sentry": {
                 "dsn": "${{ secrets.SENTRY_DSN_SYS_MONITORD }}",
                 "debug": "false",
-                "sample_rate": "${{ (github.event.inputs.environment == 'Production' || github.ref == 'refs/heads/main') && '0.1' || '1.0' }}",
-                "environment": "${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}",
+                "sample_rate": "${SENTRY_SAMPLE_RATE}",
+                "environment": "${CONFIGURATION}",
                 "release": "${{ inputs.version || github.event.inputs.version }}",
                 "repository": "${{ github.repository }}"
             }

--- a/.github/workflows/manual-build-components.yaml
+++ b/.github/workflows/manual-build-components.yaml
@@ -18,7 +18,7 @@ on:
         required: true
         type: string
       environment:
-        description: "Environment to build"
+        description: "Where to build"
         required: true
         default: "Development"
         type: choice
@@ -268,4 +268,4 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          rm -rf /components 
+          rm -rf /components

--- a/.github/workflows/manual-build-feral-player.yaml
+++ b/.github/workflows/manual-build-feral-player.yaml
@@ -8,7 +8,15 @@ on:
         required: true
         type: string
       environment:
-        description: "Environment to build"
+        description: "Where to build"
+        required: true
+        default: "Development"
+        type: choice
+        options:
+          - Development
+          - Production
+      configuration:
+        description: "Configuration set to build the package"
         required: true
         default: "Development"
         type: choice
@@ -97,7 +105,7 @@ jobs:
 
       - name: Validate required environment variables
         env:
-          NEXT_PUBLIC_ENVIRONMENT: ${{ inputs.environment || github.event.inputs.environment }}
+          NEXT_PUBLIC_ENVIRONMENT: ${{ inputs.configuration || github.event.inputs.configuration || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
           NEXT_PUBLIC_PUB_DOC_URL: ${{ vars.PUB_DOC_URL }}
           NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.SENTRY_DSN_PLAYER }}
         run: |
@@ -113,7 +121,7 @@ jobs:
       - name: Build static export
         working-directory: ff-player
         env:
-          NEXT_PUBLIC_ENVIRONMENT: ${{ inputs.environment || github.event.inputs.environment }}
+          NEXT_PUBLIC_ENVIRONMENT: ${{ inputs.configuration || github.event.inputs.configuration || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
           NEXT_PUBLIC_PUB_DOC_URL: ${{ vars.PUB_DOC_URL }}
           NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.SENTRY_DSN_PLAYER }}
           NEXT_PUBLIC_DISABLE_VERSION_CHECK: 'true'

--- a/.github/workflows/manual-push-pacman-repo.yaml
+++ b/.github/workflows/manual-push-pacman-repo.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: "Environment to build"
+        description: "Where to build"
         required: true
         default: "Development"
         type: choice
@@ -143,4 +143,4 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          rm -rf repo 
+          rm -rf repo

--- a/.github/workflows/pure-build-image-to-cf.yml
+++ b/.github/workflows/pure-build-image-to-cf.yml
@@ -16,7 +16,15 @@ on:
           - false
         default: false
       environment:
-        description: "Environment to build"
+        description: "Where to build"
+        required: true
+        default: "Development"
+        type: choice
+        options:
+          - Development
+          - Production
+      configuration:
+        description: "Configuration set to build the image"
         required: true
         default: "Development"
         type: choice
@@ -101,6 +109,7 @@ jobs:
       description: 'FF Player Static Web Application'
       maintainer: 'Feral File'
       environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
+      configuration: ${{ inputs.configuration || github.event.inputs.configuration || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}
       ff_player_ref: ${{ inputs.ff_player_ref || github.event.inputs.ff_player_ref }}
       pacman_snapshot: ${{ inputs.pacman_snapshot || github.event.inputs.pacman_snapshot }}
       container_image: ${{ needs.resolve-container.outputs.image }}
@@ -228,7 +237,9 @@ jobs:
         run: |
           set -e
 
-          if [ "${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}" = "Production" ]; then
+          CONFIGURATION="${{ inputs.configuration || github.event.inputs.configuration || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}"
+
+          if [ "$CONFIGURATION" = "Production" ]; then
             DOMAIN="ffos.feralfile.com"
           else
             DOMAIN="ffosdev.feralfile.com"
@@ -252,10 +263,19 @@ jobs:
 
       - name: Add Configs and Services
         run: |
-          if [ "${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}" = "Production" ]; then
+          CONFIGURATION="${{ inputs.configuration || github.event.inputs.configuration || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}"
+          RELAYER_ENDPOINT="wss://relayer-dev.bitmark-development.workers.dev"
+
+          if [ "$CONFIGURATION" = "Production" ]; then
             ENDPOINT="https://ffos.feralfile.com"
+            SENTRY_SAMPLE_RATE="0.1"
+            OPENPANEL_CLIENT_ID="${{ secrets.OPENPANEL_CLIENT_ID }}"
+            OPENPANEL_CLIENT_SECRET="${{ secrets.OPENPANEL_CLIENT_SECRET }}"
           else
             ENDPOINT="https://ffosdev.feralfile.com"
+            SENTRY_SAMPLE_RATE="1.0"
+            OPENPANEL_CLIENT_ID="${{ secrets.OPENPANEL_CLIENT_ID_TEST }}"
+            OPENPANEL_CLIENT_SECRET="${{ secrets.OPENPANEL_CLIENT_SECRET_TEST }}"
           fi
 
           # Add controld config
@@ -263,23 +283,30 @@ jobs:
           cat > /build/archiso-ff1/airootfs/home/feralfile/.config/controld.json << EOF
           {
             "relayer": {
-                "endpoint": "${{ vars.RELAYER_ENDPOINT }}",
+                "endpoint": "${RELAYER_ENDPOINT}",
                 "apiKey": "${{ secrets.RELAYER_API_KEY }}"
             },
             "cdp": {
                 "endpoint": "http://127.0.0.1:9222"
             },
+            "mintPairing": {
+                "enabled": true,
+                "brokerBaseURL": "https://handoff.feralfile.com",
+                "idleTTLSeconds": 300,
+                "pollIntervalMillis": 500,
+                "approvalTimeoutSeconds": 300
+            },
             "sentry": {
                 "dsn": "${{ secrets.SENTRY_DSN_CONTROLD }}",
                 "debug": "false",
-                "sample_rate": "${{ (github.event.inputs.environment == 'Production' || github.ref == 'refs/heads/main') && '0.1' || '1.0' }}",
-                "environment": "${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}",
+                "sample_rate": "${SENTRY_SAMPLE_RATE}",
+                "environment": "${CONFIGURATION}",
                 "release": "${{ inputs.version || github.event.inputs.version }}",
                 "repository": "${{ github.repository }}"
             },
             "openpanel": {
-              "clientId": "${{ github.event.inputs.environment == 'Production' && secrets.OPENPANEL_CLIENT_ID || secrets.OPENPANEL_CLIENT_ID_TEST }}",
-              "clientSecret": "${{ github.event.inputs.environment == 'Production' && secrets.OPENPANEL_CLIENT_SECRET || secrets.OPENPANEL_CLIENT_SECRET_TEST }}"
+              "clientId": "${OPENPANEL_CLIENT_ID}",
+              "clientSecret": "${OPENPANEL_CLIENT_SECRET}"
             },
             "enableHub": ${{ inputs.enable_local_hub || github.event.inputs.enable_local_hub }}
           }
@@ -295,8 +322,8 @@ jobs:
             "sentry": {
                 "dsn": "${{ secrets.SENTRY_DSN_WATCHDOG }}",
                 "debug": "false",
-                "sample_rate": "${{ (github.event.inputs.environment == 'Production' || github.ref == 'refs/heads/main') && '0.1' || '1.0' }}",
-                "environment": "${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}",
+                "sample_rate": "${SENTRY_SAMPLE_RATE}",
+                "environment": "${CONFIGURATION}",
                 "release": "${{ inputs.version || github.event.inputs.version }}",
                 "repository": "${{ github.repository }}"
             }
@@ -310,8 +337,8 @@ jobs:
             "sentry": {
                 "dsn": "${{ secrets.SENTRY_DSN_SYS_MONITORD }}",
                 "debug": "false",
-                "sample_rate": "${{ (github.event.inputs.environment == 'Production' || github.ref == 'refs/heads/main') && '0.1' || '1.0' }}",
-                "environment": "${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'Production' || 'Development') }}",
+                "sample_rate": "${SENTRY_SAMPLE_RATE}",
+                "environment": "${CONFIGURATION}",
                 "release": "${{ inputs.version || github.event.inputs.version }}",
                 "repository": "${{ github.repository }}"
             }

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ ffos/
 - `component`: Component name (feral-controld, feral-setupd, etc.)
 - `version`: Package version
 - `ffos_user_ref`: ffos-user repository reference
-- `environment`: Build environment (Development/Production)
+- `environment`: Where to build (Development/Production GitHub Environment)
+- `configuration`: Runtime configuration set to bake into image artifacts (Development/Production)
 
 **Process**:
 1. Checkout ffos-user repository using specified reference
@@ -139,7 +140,8 @@ ffos-user/users/soaktest/ → ISO /home/soaktest/ (conditional)
 - `version`: ISO version number
 - `ffos_user_ref`: ffos-user repository reference
 - `soak-test`: Include soak test components
-- `environment`: Development/Production environment
+- `environment`: Where to build (Development/Production GitHub Environment)
+- `configuration`: Runtime configuration set to bake into image artifacts
 - `is_development`: Include development tools
 - `install_to_emmc`: Build installation image
 


### PR DESCRIPTION
## Problem

The image workflows use `environment` for both the GitHub Environment where the job runs and the runtime configuration baked into the ISO, making it unclear whether the input controls deployment/secrets or device behavior.

## Why it matters

Image builds need to select where the workflow runs independently from the configuration set written into runtime artifacts like `controld.json`, `ff1-config.json`, pacman repo endpoints, Sentry labels, OpenPanel credentials, and the player static export environment.

## What changed

- Renamed the workflow-dispatch description from `Environment to build` to `Where to build`.
- Added a `configuration` input for image workflows and player package builds that controls runtime/static-export configuration values.
- Updated generated `controld.json` to use `wss://relayer-dev.bitmark-development.workers.dev` for the relayer endpoint.
- Added the `mintPairing` handoff config from feral-file/ffos-user#210 using `https://handoff.feralfile.com` as the broker base URL.

## Acceptance checks

1. Image workflows expose separate `Where to build` and `Configuration set to build the image` inputs.
2. Generated controld config includes the requested relayer endpoint and mint-pairing handoff configuration.
3. Workflow YAML validation and repository verification pass.

## Verification

- `make verify`
- `git diff --check`
